### PR TITLE
feat: add docker-compose for local stellar and soroban dev stack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,14 @@ Look for issues tagged `good first issue` — these are beginner-friendly tasks.
 ### Prerequisites
 - Node.js >= 18
 - PostgreSQL
+- Docker & Docker Compose (for the local Stellar network)
 - Rust + Soroban CLI (for smart contracts)
+
+### Local Stellar Network
+Before deploying contracts locally, spin up the standalone development network:
+```bash
+docker compose up -d
+```
 
 ### Install & Run
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ stella-polymarket/
 
 ## 🛠️ Getting Started
 
+### Local Blockchain Environment (Docker)
+To test smart contracts locally without spending real Testnet XLM, you can spin up a standalone Stellar network with the Soroban RPC enabled:
+
+```bash
+docker compose up -d
+```
+### Application Setup
 ```bash
 # Clone the repo
 git clone https://github.com/your-username/stella-polymarket.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  stellar-quickstart:
+    image: stellar/quickstart:testing
+    container_name: stellar-quickstart
+    # --local runs a standalone network. --enable-soroban-rpc turns on the Soroban RPC server.
+    command: --local --enable-soroban-rpc
+    ports:
+      - "8000:8000" # Horizon API
+      - "8001:8001" # Soroban RPC
+    volumes:
+      - stellar-data:/opt/stellar/postgresql/data
+
+volumes:
+  stellar-data:
+    name: stellar_polymarket_data


### PR DESCRIPTION
## Summary
This PR introduces a containerized local development environment to allow contributors to test Soroban smart contracts without spending real Testnet XLM or dealing with network latency.

## Related Issue
Closes #3

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation update
- [x] Other (describe): DevOps/Infrastructure setup

## Changes Made
- Added `docker-compose.yml` utilizing the `stellar/quickstart:testing` image.
- Configured the standalone network with the Soroban RPC enabled (`--local --enable-soroban-rpc`).
- Mapped ports `8000` (Horizon API) and `8001` (Soroban RPC) to the host.
- Configured a persistent Docker volume (`stellar-data`) mapped to the internal PostgreSQL directory so ledger state is not lost between container restarts.
- Updated `README.md` and `CONTRIBUTING.md` with instructions on how to spin up the local network.

## Testing
I tested the stack locally by running `docker compose up -d`. The container booted successfully, the ports mapped correctly, and the Horizon endpoint returned the correct standalone network passphrase.

**Visual Validation:**
<img width="1878" height="462" alt="image" src="https://github.com/user-attachments/assets/7374c503-08cf-4106-aab8-a334198606dc" />
<img width="1878" height="462" alt="image" src="https://github.com/user-attachments/assets/7374c503-08cf-4106-aab8-a334198606dc" />


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented complex logic where necessary
- [x] I have updated documentation if needed
- [x] My changes don't introduce new warnings or errors