### PR TITLE
feat(contracts): graceful shutdown via GlobalStatus flag

### DIFF
--- a/contracts/prediction_market/GRACEFUL_SHUTDOWN_README.md
+++ b/contracts/prediction_market/GRACEFUL_SHUTDOWN_README.md
@@ -1,0 +1,84 @@
+# Graceful Shutdown — Admin Tool
+
+## What It Does
+
+`set_global_status(active: false)` puts the platform into **graceful shutdown** mode:
+
+| Function | Shutdown behaviour |
+|----------|--------------------|
+| `create_market` | ❌ Reverts with `"Platform is shut down"` |
+| `place_bet` | ✅ Works — existing markets stay open |
+| `resolve_market` | ✅ Works — oracle can still settle |
+| `batch_distribute` | ✅ Works — winners can still claim |
+| `set_global_status(true)` | ✅ Re-activates the platform at any time |
+
+A single `GlobalStatus` boolean lives in **Instance storage** — one cheap read on
+`create_market`, zero overhead on every other function.
+
+---
+
+## Why This Is Better Than a Hard Pause
+
+A **hard pause** (circuit breaker) freezes everything:
+
+```
+Hard Pause:  create_market ❌  place_bet ❌  resolve ❌  claim ❌
+```
+
+This creates two serious problems:
+
+1. **Funds get locked.** Users who already staked cannot claim winnings until the
+   admin manually re-opens the contract — a trust and legal liability issue.
+2. **Markets can't settle.** Oracles may have already confirmed results; blocking
+   `resolve_market` means the on-chain state diverges from reality.
+
+**Graceful shutdown** is a one-way valve on *new activity* only:
+
+```
+Graceful Shutdown:  create_market ❌  place_bet ✅  resolve ✅  claim ✅
+```
+
+- Users keep full access to their funds.
+- All in-flight markets reach a natural conclusion.
+- The platform drains cleanly — no emergency intervention needed.
+- Re-activation (`set_global_status(true)`) is instant if the shutdown was precautionary.
+
+---
+
+## Usage
+
+```bash
+# Initiate graceful shutdown
+soroban contract invoke --id $CONTRACT --source $ADMIN --network testnet \
+  -- set_global_status --active false
+
+# Verify
+soroban contract invoke --id $CONTRACT --network testnet \
+  -- get_global_status
+# → false
+
+# Attempt to create a market (should revert)
+soroban contract invoke --id $CONTRACT --source $ADMIN --network testnet \
+  -- create_market --id 99 --question "Test" --options '["Yes","No"]' \
+     --deadline 9999999999 --token $TOKEN
+# → error: "Platform is shut down"
+
+# Claim still works for existing markets
+soroban contract invoke --id $CONTRACT --source $WINNER --network testnet \
+  -- batch_distribute --market_id 1 --batch_size 10
+# → succeeds
+
+# Re-activate if needed
+soroban contract invoke --id $CONTRACT --source $ADMIN --network testnet \
+  -- set_global_status --active true
+```
+
+---
+
+## Storage
+
+| Key | Tier | Default |
+|-----|------|---------|
+| `GlobalStatus` | Instance | `true` (active) |
+
+Set on `initialize`. One Instance read per `create_market` call — negligible cost.

--- a/contracts/prediction_market/src/lib.rs
+++ b/contracts/prediction_market/src/lib.rs
@@ -21,6 +21,10 @@ pub enum DataKey {
     IsPaused(u64),
     /// Hot: settlement cursor (index into winners vec) — Instance storage
     SettlementCursor(u64),
+    /// Hot: global platform status — Instance storage.
+    /// true = active (default), false = graceful shutdown.
+    /// Only blocks create_market; existing markets resolve and pay out normally.
+    GlobalStatus,
 }
 
 #[contracttype]
@@ -55,9 +59,12 @@ impl PredictionMarket {
         admin.require_auth();
         env.storage().instance().set(&DataKey::Initialized, &true);
         env.storage().instance().set(&DataKey::Admin, &admin);
+        // Platform starts active by default
+        env.storage().instance().set(&DataKey::GlobalStatus, &true);
     }
 
     /// Create a new prediction market.
+    /// Blocked when GlobalStatus is false (graceful shutdown).
     /// Hot data (total_shares, is_paused) written to Instance storage.
     /// Cold data (market metadata, user positions) written to Persistent storage.
     pub fn create_market(
@@ -70,6 +77,14 @@ impl PredictionMarket {
     ) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
+
+        // Graceful shutdown guard — checked before any other work
+        let active: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::GlobalStatus)
+            .unwrap_or(true);
+        assert!(active, "Platform is shut down");
 
         assert!(
             !env.storage().persistent().has(&DataKey::Market(id)),
@@ -163,6 +178,26 @@ impl PredictionMarket {
         env.storage()
             .instance()
             .set(&DataKey::IsPaused(market_id), &paused);
+    }
+
+    /// Graceful shutdown / re-activation (admin only).
+    /// active=false → new markets blocked; existing markets resolve and pay out normally.
+    /// active=true  → platform re-opened.
+    /// Single Instance write — cheapest possible admin action.
+    pub fn set_global_status(env: Env, active: bool) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::GlobalStatus, &active);
+    }
+
+    /// Read the current global platform status.
+    pub fn get_global_status(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::GlobalStatus)
+            .unwrap_or(true)
     }
 
     /// Resolve market — only admin (oracle-triggered).
@@ -821,5 +856,88 @@ mod tests {
         client.resolve_market(&1u64, &0u32);
         let paid = client.batch_distribute(&1u64, &5u32);
         assert_eq!(paid, 0u32);
+    }
+
+    // ── Graceful shutdown ─────────────────────────────────────────────────────
+
+    /// Platform starts active by default.
+    #[test]
+    fn test_global_status_defaults_active() {
+        let (_, client, _, _, _) = setup();
+        assert!(client.get_global_status());
+    }
+
+    /// set_global_status(false) blocks create_market.
+    #[test]
+    #[should_panic(expected = "Platform is shut down")]
+    fn test_create_market_blocked_when_shutdown() {
+        let (env, client, _, token, _) = setup();
+        client.set_global_status(&false);
+        let options = vec![
+            &env,
+            String::from_str(&env, "Yes"),
+            String::from_str(&env, "No"),
+        ];
+        client.create_market(
+            &2u64,
+            &String::from_str(&env, "New market"),
+            &options,
+            &(env.ledger().timestamp() + 100),
+            &token,
+        );
+    }
+
+    /// place_bet on an existing market still works during shutdown.
+    #[test]
+    fn test_place_bet_allowed_during_shutdown() {
+        let (env, client, _, _, _) = setup();
+        client.set_global_status(&false);
+        // market 1 was created before shutdown — betting must still work
+        let bettor = Address::generate(&env);
+        // mock_all_auths covers token transfer; no panic expected
+        client.place_bet(&1u64, &0u32, &bettor, &50i128);
+        assert_eq!(client.get_total_shares(&1u64), 50i128);
+    }
+
+    /// batch_distribute still works during shutdown.
+    #[test]
+    fn test_batch_distribute_allowed_during_shutdown() {
+        let (_, client, _) = setup_market_with_winners(3);
+        client.set_global_status(&false);
+        let paid = client.batch_distribute(&1u64, &3u32);
+        assert_eq!(paid, 3u32);
+    }
+
+    /// resolve_market still works during shutdown.
+    #[test]
+    fn test_resolve_market_allowed_during_shutdown() {
+        let (_, client, _, _, _) = setup();
+        client.set_global_status(&false);
+        client.resolve_market(&1u64, &0u32);
+        assert!(client.get_market(&1u64).resolved);
+    }
+
+    /// Re-activating the platform allows create_market again.
+    #[test]
+    fn test_reactivation_allows_create_market() {
+        let (env, client, _, token, _) = setup();
+        client.set_global_status(&false);
+        assert!(!client.get_global_status());
+        client.set_global_status(&true);
+        assert!(client.get_global_status());
+        let options = vec![
+            &env,
+            String::from_str(&env, "Yes"),
+            String::from_str(&env, "No"),
+        ];
+        // Should not panic
+        client.create_market(
+            &2u64,
+            &String::from_str(&env, "Post-reactivation market"),
+            &options,
+            &(env.ledger().timestamp() + 100),
+            &token,
+        );
+        assert_eq!(client.get_market(&2u64).id, 2u64);
     }
 }


### PR DESCRIPTION
### Summary

Adds a GlobalStatus flag in Instance storage that lets the admin block new market creation 
while leaving all existing markets fully operational — bets, resolutions, and payouts 
continue uninterrupted.

### What Changed

- DataKey::GlobalStatus — new Instance storage key, set to true on initialize
- set_global_status(active: bool) — admin-only, single Instance write
- get_global_status() — public read
- create_market — reads GlobalStatus as its first guard, panics with 
"Platform is shut down" if false
- place_bet, resolve_market, batch_distribute, distribute_rewards — untouched, no new checks

### Behaviour Matrix

| Function | Active | Shutdown |
|----------|--------|----------|
| create_market | ✅ | ❌ reverts |
| place_bet | ✅ | ✅ |
| resolve_market | ✅ | ✅ |
| batch_distribute | ✅ | ✅ |
| set_global_status(true) | — | ✅ re-activates |

### Why This Is Better Than a Hard Pause

A hard pause freezes everything — including place_bet and batch_distribute. That locks user
funds and prevents oracle-confirmed results from settling on-chain, creating a trust and 
liability problem.

Graceful shutdown is a one-way valve on new activity only. All in-flight markets drain 
naturally to completion. No emergency admin intervention needed to unblock users. Re-
activation is instant if the shutdown was precautionary.

### Tests (36 total, 6 new)

- GlobalStatus defaults to true after initialize
- create_market reverts with "Platform is shut down" when inactive
- place_bet succeeds on existing market during shutdown
- resolve_market succeeds during shutdown
- batch_distribute succeeds during shutdown
- Re-activation via set_global_status(true) restores create_market

### PR Acceptance Checklist

- [x] GlobalStatus flag lives in Instance storage — verified in DataKey enum and initialize
- [ ] Attach terminal screenshot showing create_market reverting while batch_distribute 
succeeds (see GRACEFUL_SHUTDOWN_README.md for exact commands)
- [ ] See GRACEFUL_SHUTDOWN_README.md for full soft vs hard pause comparison

closes #50 