### PR TITLE
feat: add high-volatility pulse animation to market cards

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -47,3 +47,24 @@ body {
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
+
+/* High-volatility pulse animations for market cards */
+@keyframes pulseGreen {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+  50% { box-shadow: 0 0 0 8px rgba(34, 197, 94, 0.4); }
+}
+
+@keyframes pulseRed {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); }
+  50% { box-shadow: 0 0 0 8px rgba(239, 68, 68, 0.4); }
+}
+
+.pulse-green {
+  animation: pulseGreen 0.6s ease-in-out;
+  animation-iteration-count: 3;
+}
+
+.pulse-red {
+  animation: pulseRed 0.6s ease-in-out;
+  animation-iteration-count: 3;
+}

--- a/frontend/src/components/MarketCard.tsx
+++ b/frontend/src/components/MarketCard.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { trackEvent } from "../lib/firebase";
+import { VOLATILITY_THRESHOLD } from "../lib/constants";
 
 interface Market {
   id: number;
@@ -15,13 +16,37 @@ interface Props {
   market: Market;
   walletAddress: string | null;
   onBetPlaced?: () => void;
+  odds?: number;
 }
 
-export default function MarketCard({ market, walletAddress, onBetPlaced }: Props) {
+export default function MarketCard({ market, walletAddress, onBetPlaced, odds }: Props) {
   const [selectedOutcome, setSelectedOutcome] = useState<number | null>(null);
   const [amount, setAmount] = useState("");
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
+  const [pulseClass, setPulseClass] = useState<string>("");
+
+  const prevOddsRef = useRef<number | undefined>(undefined);
+
+  // Detect volatility and trigger pulse animation
+  useEffect(() => {
+    if (odds === undefined) return;
+
+    const prevOdds = prevOddsRef.current;
+    if (prevOdds !== undefined && prevOdds !== 0) {
+      const percentChange = Math.abs((odds - prevOdds) / prevOdds * 100);
+
+      if (percentChange > VOLATILITY_THRESHOLD) {
+        // Green for rising YES odds, red for falling
+        setPulseClass(odds > prevOdds ? "pulse-green" : "pulse-red");
+      }
+    }
+    prevOddsRef.current = odds;
+  }, [odds]);
+
+  const handleAnimationEnd = () => {
+    setPulseClass("");
+  };
 
   const isExpired = new Date(market.end_date) <= new Date();
 
@@ -86,7 +111,11 @@ export default function MarketCard({ market, walletAddress, onBetPlaced }: Props
   }
 
   return (
-    <div className="bg-gray-900 rounded-xl p-5 flex flex-col gap-3 border border-gray-800">
+    <div
+      className={`bg-gray-900 rounded-xl p-5 flex flex-col gap-3 border border-gray-800 ${pulseClass}`}
+      onAnimationEnd={handleAnimationEnd}
+      data-testid="market-card"
+    >
       <div className="flex justify-between items-start">
         <h3 className="font-semibold text-white text-lg leading-snug flex-1">{market.question}</h3>
         <div className="flex items-center gap-2">

--- a/frontend/src/components/__tests__/MarketCard.test.tsx
+++ b/frontend/src/components/__tests__/MarketCard.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Tests for MarketCard volatility pulse animation
+ * Feature: high-volatility-pulse (#122)
+ */
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import MarketCard from "../MarketCard";
+import { VOLATILITY_THRESHOLD } from "../../lib/constants";
+
+const SAMPLE_MARKET = {
+  id: 1,
+  question: "Will Bitcoin reach $100k?",
+  end_date: "2026-12-31T00:00:00Z",
+  outcomes: ["Yes", "No"],
+  resolved: false,
+  winning_outcome: null,
+  total_pool: "4200",
+};
+
+describe("MarketCard — Volatility Pulse Animation", () => {
+  it("does not apply pulse class on initial render", () => {
+    render(
+      <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={50} />
+    );
+    const card = screen.getByTestId("market-card");
+    expect(card).not.toHaveClass("pulse-green");
+    expect(card).not.toHaveClass("pulse-red");
+  });
+
+  it("applies pulse-green when odds increase above threshold", () => {
+    const { rerender } = render(
+      <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={50} />
+    );
+
+    // Increase odds by more than VOLATILITY_THRESHOLD (5%)
+    const newOdds = 50 * (1 + (VOLATILITY_THRESHOLD + 1) / 100);
+    rerender(
+      <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={newOdds} />
+    );
+
+    const card = screen.getByTestId("market-card");
+    expect(card).toHaveClass("pulse-green");
+  });
+
+  it("applies pulse-red when odds decrease above threshold", () => {
+    const { rerender } = render(
+      <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={50} />
+    );
+
+    // Decrease odds by more than VOLATILITY_THRESHOLD (5%)
+    const newOdds = 50 * (1 - (VOLATILITY_THRESHOLD + 1) / 100);
+    rerender(
+      <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={newOdds} />
+    );
+
+    const card = screen.getByTestId("market-card");
+    expect(card).toHaveClass("pulse-red");
+  });
+
+  it("does not apply pulse class when change is below threshold", () => {
+    const { rerender } = render(
+      <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={50} />
+    );
+
+    // Change by less than VOLATILITY_THRESHOLD
+    const newOdds = 50 * (1 + (VOLATILITY_THRESHOLD - 1) / 100);
+    rerender(
+      <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={newOdds} />
+    );
+
+    const card = screen.getByTestId("market-card");
+    expect(card).not.toHaveClass("pulse-green");
+    expect(card).not.toHaveClass("pulse-red");
+  });
+
+  it("removes pulse class after animation ends", () => {
+    const { rerender } = render(
+      <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={50} />
+    );
+
+    // Trigger pulse
+    rerender(
+      <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={60} />
+    );
+
+    const card = screen.getByTestId("market-card");
+    expect(card).toHaveClass("pulse-green");
+
+    // Simulate animation end
+    act(() => {
+      card.dispatchEvent(new Event("animationend", { bubbles: true }));
+    });
+
+    expect(card).not.toHaveClass("pulse-green");
+  });
+
+  it("works correctly when multiple cards exist simultaneously", () => {
+    const market2 = { ...SAMPLE_MARKET, id: 2, question: "Will ETH reach $10k?" };
+
+    const { rerender } = render(
+      <>
+        <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={50} />
+        <MarketCard market={market2} walletAddress={null} odds={30} />
+      </>
+    );
+
+    rerender(
+      <>
+        <MarketCard market={SAMPLE_MARKET} walletAddress={null} odds={60} />
+        <MarketCard market={market2} walletAddress={null} odds={25} />
+      </>
+    );
+
+    const cards = screen.getAllByTestId("market-card");
+    expect(cards[0]).toHaveClass("pulse-green");
+    expect(cards[1]).toHaveClass("pulse-red");
+  });
+});
+
+describe("VOLATILITY_THRESHOLD constant", () => {
+  it("is exported and equals 5", () => {
+    expect(VOLATILITY_THRESHOLD).toBe(5);
+  });
+});

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Volatility threshold for market card pulse animation.
+ * Pulse triggers when odds change by more than this percentage.
+ */
+export const VOLATILITY_THRESHOLD = 5;


### PR DESCRIPTION
Closes #122
## Summary

- Adds visual pulse animation to market cards when odds change by more than 5%
- Green glow for rising YES odds, red glow for falling odds
- Animation runs 3 cycles then stops automatically
- Introduces configurable `VOLATILITY_THRESHOLD` constant

## Root Cause

Market cards lacked visual feedback for rapid odds changes, requiring users to constantly monitor numbers to detect volatility.

## Changes

- Created `frontend/src/lib/constants.ts` with `VOLATILITY_THRESHOLD = 5`
- Added `@keyframes pulseGreen` and `pulseRed` animations to `globals.css`
- Updated `MarketCard.tsx` to track odds via `useRef` and trigger pulse when threshold exceeded
- Added unit tests covering green/red logic, threshold boundaries, and animation cleanup

## Test Plan

- [ ] Verify green pulse triggers when odds increase by more than 5%
- [ ] Verify red pulse triggers when odds decrease by more than 5%
- [ ] Verify animation runs exactly 3 cycles
- [ ] Verify no layout shift occurs during animation
- [ ] Verify multiple cards can pulse simultaneously without interference
- [ ] Run `npm test -- MarketCard` to confirm all unit tests pass
