### PR TITLE
feat: implement Go ledger event scraper with goroutine parallelism

### DIFF
--- a/scraper/README.md
+++ b/scraper/README.md
@@ -1,0 +1,113 @@
+# Ledger Event Scraper
+
+Go service that scrapes Stellar Horizon ledger operations and persists matching contract invocation events to PostgreSQL.
+
+## Features
+
+- Scrapes Stellar ledger operations via the Horizon REST API
+- Filters for Soroban `invoke_host_function` operations matching a contract address
+- Concurrent processing with a configurable goroutine worker pool
+- Catch-up mode: start from any historical ledger with `--start-ledger`
+- Resume mode: automatically continues from the last processed ledger stored in the database
+- Stores events as structured JSONB for flexible querying
+
+## Prerequisites
+
+- Go 1.22+
+- PostgreSQL 14+
+
+## Configuration
+
+| Environment Variable | Description | Default |
+|---|---|---|
+| `HORIZON_URL` | Stellar Horizon API endpoint | `https://horizon-testnet.stellar.org` |
+| `DATABASE_URL` | PostgreSQL connection string | *required* |
+| `CONTRACT_ADDRESS` | Soroban contract address to filter | (none — scrape all invocations) |
+| `WORKER_COUNT` | Number of concurrent ledger workers | `10` |
+| `POLL_INTERVAL_SEC` | Seconds between polls when caught up | `5` |
+
+## Usage
+
+```bash
+# Build
+cd scraper
+go build -o scraper .
+
+# Run (resume from last checkpoint)
+DATABASE_URL="postgres://user:pass@localhost:5432/polymarket?sslmode=disable" \
+CONTRACT_ADDRESS="CABC123..." \
+  ./scraper
+
+# Catch-up from a specific ledger
+./scraper --start-ledger 1000000
+
+# Override contract address via flag
+./scraper --contract-address CXYZ789...
+```
+
+## Database Schema
+
+The scraper automatically creates two tables on startup:
+
+### `ledger_events`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `BIGSERIAL` | Primary key |
+| `ledger_seq` | `BIGINT` | Ledger sequence number |
+| `tx_hash` | `TEXT` | Transaction hash |
+| `event_type` | `TEXT` | Function name or `contract_invoke` |
+| `data` | `JSONB` | Full operation details |
+| `timestamp` | `TIMESTAMPTZ` | Operation timestamp from Horizon |
+| `created_at` | `TIMESTAMPTZ` | Row insertion time |
+
+### `scraper_state`
+
+Single-row table tracking the last fully processed ledger.
+
+## Querying Events
+
+```sql
+-- Recent events for a contract
+SELECT event_type, tx_hash, data, timestamp
+FROM ledger_events
+WHERE ledger_seq > 1000000
+ORDER BY ledger_seq DESC
+LIMIT 50;
+
+-- Count events by type
+SELECT event_type, COUNT(*)
+FROM ledger_events
+GROUP BY event_type
+ORDER BY count DESC;
+
+-- Find events by function parameters
+SELECT *
+FROM ledger_events
+WHERE data->>'function' = 'place_bet'
+  AND timestamp > NOW() - INTERVAL '24 hours';
+```
+
+## Testing
+
+```bash
+go test -v ./...
+```
+
+## Architecture
+
+```
+main.go          CLI entrypoint, signal handling, dependency wiring
+config/          Environment-based configuration loading
+scraper/         Core scraping loop, Horizon API client, event filtering
+store/           PostgreSQL persistence (events + scraper state)
+```
+
+The scraper runs a main loop that:
+
+1. Fetches the latest ledger sequence from Horizon
+2. Distributes a batch of ledger sequences to a goroutine worker pool
+3. Each worker fetches operations for its ledger and filters for contract invocations
+4. Results are collected and saved in sequential order
+5. The last-processed ledger marker is updated after each successful save
+6. When caught up, the scraper polls at the configured interval

--- a/scraper/config/config.go
+++ b/scraper/config/config.go
@@ -1,0 +1,77 @@
+// Package config provides environment-based configuration for the ledger event scraper.
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+const (
+	defaultHorizonURL  = "https://horizon-testnet.stellar.org"
+	defaultWorkerCount = 10
+	defaultPollInterval = 5 // seconds
+)
+
+// Config holds all configuration values for the scraper service.
+type Config struct {
+	// HorizonURL is the Stellar Horizon API endpoint.
+	HorizonURL string
+
+	// DatabaseURL is the PostgreSQL connection string.
+	DatabaseURL string
+
+	// ContractAddress is the Soroban contract address to filter events for.
+	ContractAddress string
+
+	// WorkerCount is the number of concurrent goroutines for processing ledgers.
+	WorkerCount int
+
+	// PollIntervalSec is how many seconds to wait before polling for new ledgers.
+	PollIntervalSec int
+}
+
+// Load reads configuration from environment variables, applying sensible defaults
+// where possible. It returns an error if required values (DATABASE_URL) are missing.
+func Load() (*Config, error) {
+	cfg := &Config{
+		HorizonURL:      envOrDefault("HORIZON_URL", defaultHorizonURL),
+		DatabaseURL:     os.Getenv("DATABASE_URL"),
+		ContractAddress: os.Getenv("CONTRACT_ADDRESS"),
+		WorkerCount:     envIntOrDefault("WORKER_COUNT", defaultWorkerCount),
+		PollIntervalSec: envIntOrDefault("POLL_INTERVAL_SEC", defaultPollInterval),
+	}
+
+	if cfg.DatabaseURL == "" {
+		return nil, fmt.Errorf("DATABASE_URL environment variable is required")
+	}
+
+	if cfg.WorkerCount < 1 {
+		cfg.WorkerCount = defaultWorkerCount
+	}
+
+	return cfg, nil
+}
+
+// envOrDefault returns the value of the named environment variable, or fallback
+// if the variable is empty or unset.
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// envIntOrDefault returns the integer value of the named environment variable,
+// or fallback if the variable is empty, unset, or not a valid integer.
+func envIntOrDefault(key string, fallback int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return n
+}

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -1,0 +1,5 @@
+module github.com/Hahfyeex/Stellar-PolyMarket/scraper
+
+go 1.22
+
+require github.com/lib/pq v1.10.9

--- a/scraper/go.sum
+++ b/scraper/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKFbGRn7nbIqu9HhEDnDfBij0=

--- a/scraper/main.go
+++ b/scraper/main.go
@@ -1,0 +1,65 @@
+// Ledger Event Scraper — a Go service that scrapes Stellar ledger events
+// from the Horizon API and persists matching contract invocations to PostgreSQL.
+//
+// Usage:
+//
+//	scraper [--start-ledger N] [--contract-address ADDR]
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Hahfyeex/Stellar-PolyMarket/scraper/config"
+	scr "github.com/Hahfyeex/Stellar-PolyMarket/scraper/scraper"
+	"github.com/Hahfyeex/Stellar-PolyMarket/scraper/store"
+)
+
+func main() {
+	startLedger := flag.Int64("start-ledger", 0, "ledger sequence to start scraping from (0 = resume from DB)")
+	contractAddr := flag.String("contract-address", "", "Soroban contract address to filter (overrides CONTRACT_ADDRESS env)")
+	flag.Parse()
+
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	// CLI flag overrides env var.
+	if *contractAddr != "" {
+		cfg.ContractAddress = *contractAddr
+	}
+
+	log.Printf("horizon: %s", cfg.HorizonURL)
+	log.Printf("contract filter: %s", cfg.ContractAddress)
+	log.Printf("workers: %d", cfg.WorkerCount)
+
+	st, err := store.New(cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+	defer st.Close()
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	pollInterval := time.Duration(cfg.PollIntervalSec) * time.Second
+
+	s := scr.New(cfg.HorizonURL, cfg.ContractAddress, cfg.WorkerCount, pollInterval, client, st)
+
+	// Graceful shutdown on SIGINT / SIGTERM.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		log.Printf("received %s, shutting down...", sig)
+		s.Stop()
+	}()
+
+	if err := s.Run(*startLedger); err != nil {
+		log.Fatalf("scraper error: %v", err)
+	}
+}

--- a/scraper/scraper/scraper.go
+++ b/scraper/scraper/scraper.go
@@ -1,0 +1,306 @@
+// Package scraper implements the core ledger event scraping logic.
+// It polls the Stellar Horizon API for ledger operations, filters by
+// contract address, and persists matching events to PostgreSQL.
+package scraper
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Hahfyeex/Stellar-PolyMarket/scraper/store"
+)
+
+// HorizonClient defines the HTTP interface used by the scraper, making it
+// easy to swap in a mock for testing.
+type HorizonClient interface {
+	Get(url string) (*http.Response, error)
+}
+
+// EventStore defines the storage interface used by the scraper.
+type EventStore interface {
+	SaveEvents(events []*store.Event) error
+	GetLastProcessedLedger() (int64, error)
+	UpdateLastProcessedLedger(seq int64) error
+}
+
+// Scraper coordinates ledger scraping with a pool of concurrent workers.
+type Scraper struct {
+	horizonURL      string
+	contractAddress string
+	workerCount     int
+	pollInterval    time.Duration
+	client          HorizonClient
+	store           EventStore
+	stopCh          chan struct{}
+}
+
+// New creates a Scraper with the given configuration.
+func New(horizonURL, contractAddress string, workerCount int, pollInterval time.Duration, client HorizonClient, st EventStore) *Scraper {
+	return &Scraper{
+		horizonURL:      strings.TrimRight(horizonURL, "/"),
+		contractAddress: contractAddress,
+		workerCount:     workerCount,
+		pollInterval:    pollInterval,
+		client:          client,
+		store:           st,
+		stopCh:          make(chan struct{}),
+	}
+}
+
+// Run starts the scraping loop. If startLedger > 0 it begins from that ledger
+// (catch-up mode); otherwise it resumes from the last processed ledger stored
+// in the database. Run blocks until Stop is called or a fatal error occurs.
+func (s *Scraper) Run(startLedger int64) error {
+	seq := startLedger
+
+	if seq <= 0 {
+		last, err := s.store.GetLastProcessedLedger()
+		if err != nil {
+			return fmt.Errorf("load resume point: %w", err)
+		}
+		seq = last + 1
+		log.Printf("resuming from ledger %d (last processed: %d)", seq, last)
+	} else {
+		log.Printf("starting catch-up from ledger %d", seq)
+	}
+
+	for {
+		select {
+		case <-s.stopCh:
+			log.Println("scraper stopped")
+			return nil
+		default:
+		}
+
+		latestLedger, err := s.getLatestLedgerSeq()
+		if err != nil {
+			log.Printf("error fetching latest ledger: %v, retrying in %v", err, s.pollInterval)
+			time.Sleep(s.pollInterval)
+			continue
+		}
+
+		if seq > latestLedger {
+			// We are caught up; wait for new ledgers.
+			time.Sleep(s.pollInterval)
+			continue
+		}
+
+		// Process a batch of ledgers concurrently.
+		end := seq + int64(s.workerCount)
+		if end > latestLedger+1 {
+			end = latestLedger + 1
+		}
+
+		if err := s.processBatch(seq, end); err != nil {
+			log.Printf("error processing batch [%d, %d): %v", seq, end, err)
+			time.Sleep(s.pollInterval)
+			continue
+		}
+
+		seq = end
+	}
+}
+
+// Stop signals the scraper to shut down gracefully.
+func (s *Scraper) Stop() {
+	close(s.stopCh)
+}
+
+// processBatch processes ledgers in [start, end) using a goroutine pool.
+// Results are collected and saved in sequential order so the last-processed
+// ledger marker stays consistent.
+func (s *Scraper) processBatch(start, end int64) error {
+	count := int(end - start)
+	type result struct {
+		seq    int64
+		events []*store.Event
+		err    error
+	}
+
+	results := make([]result, count)
+	jobs := make(chan int, count)
+	var wg sync.WaitGroup
+
+	// Launch worker goroutines.
+	for w := 0; w < s.workerCount && w < count; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range jobs {
+				ledgerSeq := start + int64(idx)
+				events, err := s.processLedger(ledgerSeq)
+				results[idx] = result{seq: ledgerSeq, events: events, err: err}
+			}
+		}()
+	}
+
+	// Send jobs.
+	for i := 0; i < count; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+
+	// Save results in order and update the progress marker.
+	for _, r := range results {
+		if r.err != nil {
+			return fmt.Errorf("ledger %d: %w", r.seq, r.err)
+		}
+		if len(r.events) > 0 {
+			if err := s.store.SaveEvents(r.events); err != nil {
+				return fmt.Errorf("save events for ledger %d: %w", r.seq, err)
+			}
+			log.Printf("ledger %d: saved %d event(s)", r.seq, len(r.events))
+		}
+		if err := s.store.UpdateLastProcessedLedger(r.seq); err != nil {
+			return fmt.Errorf("update progress for ledger %d: %w", r.seq, err)
+		}
+	}
+
+	return nil
+}
+
+// processLedger fetches operations for a single ledger and returns matching events.
+func (s *Scraper) processLedger(seq int64) ([]*store.Event, error) {
+	ops, err := s.fetchOperations(seq)
+	if err != nil {
+		return nil, err
+	}
+	return FilterEvents(ops, s.contractAddress, seq), nil
+}
+
+// horizonOperationsResponse represents the Horizon API response for listing
+// operations within a ledger.
+type horizonOperationsResponse struct {
+	Embedded struct {
+		Records []HorizonOperationPublic `json:"records"`
+	} `json:"_embedded"`
+}
+
+// HorizonOperationPublic represents a single Horizon operation record.
+// Exported so that external test packages can construct test data.
+type HorizonOperationPublic struct {
+	ID              string          `json:"id"`
+	Type            string          `json:"type"`
+	TransactionHash string          `json:"transaction_hash"`
+	SourceAccount   string          `json:"source_account"`
+	CreatedAt       string          `json:"created_at"`
+	// Soroban invoke fields
+	Function        string          `json:"function,omitempty"`
+	ContractID      string          `json:"contract_id,omitempty"`
+	Parameters      json.RawMessage `json:"parameters,omitempty"`
+}
+
+// HorizonOperationForTest is an alias for HorizonOperationPublic, provided
+// for readability in test code.
+type HorizonOperationForTest = HorizonOperationPublic
+
+// fetchOperations retrieves all operations for the given ledger sequence
+// from the Horizon API.
+func (s *Scraper) fetchOperations(seq int64) ([]HorizonOperationPublic, error) {
+	url := fmt.Sprintf("%s/ledgers/%d/operations?limit=200&order=asc", s.horizonURL, seq)
+
+	resp, err := s.client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		// Ledger does not exist yet.
+		return nil, fmt.Errorf("ledger %d not found (404)", seq)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("GET %s returned %d: %s", url, resp.StatusCode, string(body))
+	}
+
+	var result horizonOperationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response for ledger %d: %w", seq, err)
+	}
+
+	return result.Embedded.Records, nil
+}
+
+// getLatestLedgerSeq fetches the most recent ledger sequence from Horizon.
+func (s *Scraper) getLatestLedgerSeq() (int64, error) {
+	url := fmt.Sprintf("%s/ledgers?limit=1&order=desc", s.horizonURL)
+
+	resp, err := s.client.Get(url)
+	if err != nil {
+		return 0, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
+	}
+
+	var result struct {
+		Embedded struct {
+			Records []struct {
+				Sequence int64 `json:"sequence"`
+			} `json:"records"`
+		} `json:"_embedded"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("decode latest ledger: %w", err)
+	}
+	if len(result.Embedded.Records) == 0 {
+		return 0, fmt.Errorf("no ledgers found")
+	}
+
+	return result.Embedded.Records[0].Sequence, nil
+}
+
+// FilterEvents inspects a set of Horizon operations and extracts events
+// that match the configured contract address. If contractAddress is empty,
+// all invoke_host_function operations are returned.
+func FilterEvents(ops []HorizonOperationPublic, contractAddress string, ledgerSeq int64) []*store.Event {
+	var events []*store.Event
+
+	for _, op := range ops {
+		// Only consider Soroban contract invocations.
+		if op.Type != "invoke_host_function" {
+			continue
+		}
+
+		// Filter by contract address when one is configured.
+		if contractAddress != "" && op.ContractID != contractAddress {
+			continue
+		}
+
+		ts, _ := time.Parse(time.RFC3339, op.CreatedAt)
+
+		data, _ := json.Marshal(map[string]interface{}{
+			"operation_id":   op.ID,
+			"function":       op.Function,
+			"contract_id":    op.ContractID,
+			"source_account": op.SourceAccount,
+			"parameters":     op.Parameters,
+		})
+
+		eventType := "contract_invoke"
+		if op.Function != "" {
+			eventType = op.Function
+		}
+
+		events = append(events, &store.Event{
+			LedgerSeq: ledgerSeq,
+			TxHash:    op.TransactionHash,
+			EventType: eventType,
+			Data:      data,
+			Timestamp: ts,
+		})
+	}
+
+	return events
+}

--- a/scraper/scraper_test.go
+++ b/scraper/scraper_test.go
@@ -1,0 +1,361 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	scr "github.com/Hahfyeex/Stellar-PolyMarket/scraper/scraper"
+	"github.com/Hahfyeex/Stellar-PolyMarket/scraper/store"
+)
+
+// --- Mock store ---
+
+type mockStore struct {
+	mu             sync.Mutex
+	events         []*store.Event
+	lastProcessed  int64
+	saveErr        error
+	updateErr      error
+}
+
+func (m *mockStore) SaveEvents(events []*store.Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.events = append(m.events, events...)
+	return nil
+}
+
+func (m *mockStore) GetLastProcessedLedger() (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastProcessed, nil
+}
+
+func (m *mockStore) UpdateLastProcessedLedger(seq int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.lastProcessed = seq
+	return nil
+}
+
+// --- Tests ---
+
+func TestFilterEvents_MatchesContractAddress(t *testing.T) {
+	ops := []scr.HorizonOperationForTest{
+		{
+			ID:              "op1",
+			Type:            "invoke_host_function",
+			TransactionHash: "tx1",
+			ContractID:      "CONTRACT_A",
+			Function:        "place_bet",
+			CreatedAt:       "2025-01-01T00:00:00Z",
+			SourceAccount:   "GABC",
+		},
+		{
+			ID:              "op2",
+			Type:            "invoke_host_function",
+			TransactionHash: "tx2",
+			ContractID:      "CONTRACT_B",
+			Function:        "resolve",
+			CreatedAt:       "2025-01-01T00:00:01Z",
+			SourceAccount:   "GDEF",
+		},
+		{
+			ID:              "op3",
+			Type:            "payment",
+			TransactionHash: "tx3",
+			CreatedAt:       "2025-01-01T00:00:02Z",
+			SourceAccount:   "GHIJ",
+		},
+	}
+
+	horizonOps := toHorizonOps(ops)
+
+	// Filter for CONTRACT_A only.
+	events := scr.FilterEvents(horizonOps, "CONTRACT_A", 100)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].TxHash != "tx1" {
+		t.Errorf("expected tx1, got %s", events[0].TxHash)
+	}
+	if events[0].EventType != "place_bet" {
+		t.Errorf("expected event type place_bet, got %s", events[0].EventType)
+	}
+}
+
+func TestFilterEvents_NoFilter_ReturnsAllInvocations(t *testing.T) {
+	ops := []scr.HorizonOperationForTest{
+		{
+			ID:              "op1",
+			Type:            "invoke_host_function",
+			TransactionHash: "tx1",
+			ContractID:      "CONTRACT_A",
+			CreatedAt:       "2025-01-01T00:00:00Z",
+			SourceAccount:   "GABC",
+		},
+		{
+			ID:              "op2",
+			Type:            "invoke_host_function",
+			TransactionHash: "tx2",
+			ContractID:      "CONTRACT_B",
+			CreatedAt:       "2025-01-01T00:00:01Z",
+			SourceAccount:   "GDEF",
+		},
+		{
+			ID:              "op3",
+			Type:            "payment",
+			TransactionHash: "tx3",
+			CreatedAt:       "2025-01-01T00:00:02Z",
+			SourceAccount:   "GHIJ",
+		},
+	}
+
+	horizonOps := toHorizonOps(ops)
+
+	// Empty contract address means no filtering.
+	events := scr.FilterEvents(horizonOps, "", 200)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+}
+
+func TestFilterEvents_IgnoresNonInvokeOps(t *testing.T) {
+	ops := []scr.HorizonOperationForTest{
+		{ID: "op1", Type: "payment", TransactionHash: "tx1", CreatedAt: "2025-01-01T00:00:00Z"},
+		{ID: "op2", Type: "create_account", TransactionHash: "tx2", CreatedAt: "2025-01-01T00:00:01Z"},
+	}
+
+	horizonOps := toHorizonOps(ops)
+	events := scr.FilterEvents(horizonOps, "", 300)
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events, got %d", len(events))
+	}
+}
+
+func TestGoroutinePoolProcessesConcurrently(t *testing.T) {
+	// Set up a Horizon mock that tracks concurrent requests.
+	var concurrentRequests int64
+	var maxConcurrent int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cur := atomic.AddInt64(&concurrentRequests, 1)
+
+		// Track the peak concurrency.
+		for {
+			old := atomic.LoadInt64(&maxConcurrent)
+			if cur <= old || atomic.CompareAndSwapInt64(&maxConcurrent, old, cur) {
+				break
+			}
+		}
+
+		// Simulate some work.
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt64(&concurrentRequests, -1)
+
+		// Return an appropriate response based on the URL.
+		if r.URL.Path == "/ledgers" {
+			// Latest ledger query.
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"_embedded": map[string]interface{}{
+					"records": []map[string]interface{}{
+						{"sequence": 110},
+					},
+				},
+			})
+			return
+		}
+
+		// Ledger operations query — return empty.
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"_embedded": map[string]interface{}{
+				"records": []interface{}{},
+			},
+		})
+	}))
+	defer server.Close()
+
+	ms := &mockStore{lastProcessed: 99}
+	s := scr.New(server.URL, "", 5, 100*time.Millisecond, server.Client(), ms)
+
+	// Run scraper in background, stop after it processes a batch.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		s.Stop()
+	}()
+
+	_ = s.Run(100)
+
+	peak := atomic.LoadInt64(&maxConcurrent)
+	if peak < 2 {
+		t.Errorf("expected concurrent requests >= 2, got %d (pool not working)", peak)
+	}
+}
+
+func TestCatchUpFromStartLedger(t *testing.T) {
+	// Verify that --start-ledger overrides the DB resume point.
+	ms := &mockStore{lastProcessed: 50}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ledgers" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"_embedded": map[string]interface{}{
+					"records": []map[string]interface{}{
+						{"sequence": 12},
+					},
+				},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"_embedded": map[string]interface{}{
+				"records": []interface{}{},
+			},
+		})
+	}))
+	defer server.Close()
+
+	s := scr.New(server.URL, "", 2, 50*time.Millisecond, server.Client(), ms)
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		s.Stop()
+	}()
+
+	// Start from ledger 10, NOT 51 (the DB resume point).
+	_ = s.Run(10)
+
+	ms.mu.Lock()
+	last := ms.lastProcessed
+	ms.mu.Unlock()
+
+	if last < 10 {
+		t.Errorf("expected last processed >= 10 (catch-up start), got %d", last)
+	}
+}
+
+func TestResumeFromLastProcessedLedger(t *testing.T) {
+	// When start-ledger is 0 the scraper should resume from DB state.
+	ms := &mockStore{lastProcessed: 75}
+
+	requestedPaths := make([]string, 0)
+	var pathsMu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pathsMu.Lock()
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		pathsMu.Unlock()
+
+		if r.URL.Path == "/ledgers" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"_embedded": map[string]interface{}{
+					"records": []map[string]interface{}{
+						{"sequence": 78},
+					},
+				},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"_embedded": map[string]interface{}{
+				"records": []interface{}{},
+			},
+		})
+	}))
+	defer server.Close()
+
+	s := scr.New(server.URL, "", 2, 50*time.Millisecond, server.Client(), ms)
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		s.Stop()
+	}()
+
+	// 0 means resume mode.
+	_ = s.Run(0)
+
+	// It should have requested ledger 76 (lastProcessed+1), not 1.
+	pathsMu.Lock()
+	defer pathsMu.Unlock()
+
+	found := false
+	for _, p := range requestedPaths {
+		if p == "/ledgers/76/operations" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected request for ledger 76 (resume from 75), paths: %v", requestedPaths)
+	}
+}
+
+func TestFilterEvents_FunctionNameAsEventType(t *testing.T) {
+	ops := []scr.HorizonOperationForTest{
+		{
+			ID:              "op1",
+			Type:            "invoke_host_function",
+			TransactionHash: "tx1",
+			ContractID:      "C_ADDR",
+			Function:        "create_market",
+			CreatedAt:       "2025-06-01T12:00:00Z",
+			SourceAccount:   "GABC",
+		},
+		{
+			ID:              "op2",
+			Type:            "invoke_host_function",
+			TransactionHash: "tx2",
+			ContractID:      "C_ADDR",
+			Function:        "",
+			CreatedAt:       "2025-06-01T12:00:01Z",
+			SourceAccount:   "GDEF",
+		},
+	}
+
+	horizonOps := toHorizonOps(ops)
+	events := scr.FilterEvents(horizonOps, "C_ADDR", 500)
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].EventType != "create_market" {
+		t.Errorf("expected create_market, got %s", events[0].EventType)
+	}
+	if events[1].EventType != "contract_invoke" {
+		t.Errorf("expected contract_invoke for empty function, got %s", events[1].EventType)
+	}
+}
+
+// --- Helpers ---
+
+// toHorizonOps converts test structs to the scraper's internal type.
+// We use a JSON round-trip so the test does not depend on unexported fields.
+func toHorizonOps(ops []scr.HorizonOperationForTest) []scr.HorizonOperationPublic {
+	result := make([]scr.HorizonOperationPublic, len(ops))
+	for i, op := range ops {
+		b, _ := json.Marshal(op)
+		_ = json.Unmarshal(b, &result[i])
+	}
+	return result
+}
+
+// Verify that mockStore satisfies EventStore at compile time.
+var _ scr.EventStore = (*mockStore)(nil)
+
+// Verify that the HTTP test server client satisfies HorizonClient.
+func TestHTTPClientSatisfiesInterface(t *testing.T) {
+	var _ scr.HorizonClient = &http.Client{}
+	_ = fmt.Sprintf("compile-time check passed")
+}

--- a/scraper/store/postgres.go
+++ b/scraper/store/postgres.go
@@ -1,0 +1,155 @@
+// Package store provides PostgreSQL storage for scraped ledger events.
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// Event represents a single contract event extracted from a ledger operation.
+type Event struct {
+	LedgerSeq int64
+	TxHash    string
+	EventType string
+	Data      json.RawMessage
+	Timestamp time.Time
+	CreatedAt time.Time
+}
+
+// Store wraps a PostgreSQL connection and provides methods for persisting
+// scraped events and tracking scraper progress.
+type Store struct {
+	db *sql.DB
+}
+
+// New opens a PostgreSQL connection and ensures the required tables exist.
+func New(databaseURL string) (*Store, error) {
+	db, err := sql.Open("postgres", databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+
+	s := &Store{db: db}
+	if err := s.migrate(); err != nil {
+		return nil, fmt.Errorf("migrate database: %w", err)
+	}
+
+	return s, nil
+}
+
+// NewWithDB creates a Store using an existing *sql.DB connection.
+// This is useful for testing with mock databases.
+func NewWithDB(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// migrate creates the required tables if they do not already exist.
+func (s *Store) migrate() error {
+	schema := `
+	CREATE TABLE IF NOT EXISTS ledger_events (
+		id          BIGSERIAL PRIMARY KEY,
+		ledger_seq  BIGINT      NOT NULL,
+		tx_hash     TEXT        NOT NULL,
+		event_type  TEXT        NOT NULL,
+		data        JSONB       NOT NULL DEFAULT '{}',
+		timestamp   TIMESTAMPTZ NOT NULL,
+		created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_ledger_events_ledger_seq ON ledger_events (ledger_seq);
+	CREATE INDEX IF NOT EXISTS idx_ledger_events_event_type ON ledger_events (event_type);
+	CREATE INDEX IF NOT EXISTS idx_ledger_events_tx_hash    ON ledger_events (tx_hash);
+
+	CREATE TABLE IF NOT EXISTS scraper_state (
+		id                  INT PRIMARY KEY DEFAULT 1,
+		last_processed_ledger BIGINT NOT NULL DEFAULT 0,
+		updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+		CONSTRAINT single_row CHECK (id = 1)
+	);
+
+	INSERT INTO scraper_state (id, last_processed_ledger)
+	VALUES (1, 0)
+	ON CONFLICT (id) DO NOTHING;
+	`
+
+	_, err := s.db.Exec(schema)
+	return err
+}
+
+// SaveEvent inserts a new event record into the ledger_events table.
+func (s *Store) SaveEvent(e *Event) error {
+	query := `
+		INSERT INTO ledger_events (ledger_seq, tx_hash, event_type, data, timestamp)
+		VALUES ($1, $2, $3, $4, $5)
+	`
+	_, err := s.db.Exec(query, e.LedgerSeq, e.TxHash, e.EventType, e.Data, e.Timestamp)
+	if err != nil {
+		return fmt.Errorf("save event: %w", err)
+	}
+	return nil
+}
+
+// SaveEvents inserts multiple events in a single transaction.
+func (s *Store) SaveEvents(events []*Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO ledger_events (ledger_seq, tx_hash, event_type, data, timestamp)
+		VALUES ($1, $2, $3, $4, $5)
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, e := range events {
+		if _, err := stmt.Exec(e.LedgerSeq, e.TxHash, e.EventType, e.Data, e.Timestamp); err != nil {
+			return fmt.Errorf("insert event (ledger %d, tx %s): %w", e.LedgerSeq, e.TxHash, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// GetLastProcessedLedger returns the last ledger sequence that was fully processed.
+func (s *Store) GetLastProcessedLedger() (int64, error) {
+	var seq int64
+	err := s.db.QueryRow("SELECT last_processed_ledger FROM scraper_state WHERE id = 1").Scan(&seq)
+	if err != nil {
+		return 0, fmt.Errorf("get last processed ledger: %w", err)
+	}
+	return seq, nil
+}
+
+// UpdateLastProcessedLedger persists the most recently completed ledger sequence.
+func (s *Store) UpdateLastProcessedLedger(seq int64) error {
+	_, err := s.db.Exec(
+		"UPDATE scraper_state SET last_processed_ledger = $1, updated_at = NOW() WHERE id = 1",
+		seq,
+	)
+	if err != nil {
+		return fmt.Errorf("update last processed ledger: %w", err)
+	}
+	return nil
+}
+
+// Close closes the underlying database connection.
+func (s *Store) Close() error {
+	return s.db.Close()
+}


### PR DESCRIPTION
## Summary
- New Go service in `scraper/` that scrapes Stellar ledger events ledger-by-ledger
- Calls Horizon `GET /ledgers/:sequence/operations` and filters by contract address
- **Goroutine worker pool** (10 concurrent via buffered channel + sync.WaitGroup)
- **PostgreSQL storage** with columns: ledger_seq, tx_hash, event_type, data (jsonb), timestamp
- **Catch-up mode**: `--start-ledger` CLI flag for processing historical ledgers
- **Resume**: tracks last processed ledger in DB, resumes after restart
- Configurable via env vars: HORIZON_URL, DATABASE_URL, CONTRACT_ADDRESS, WORKER_COUNT

Closes #151

## Test plan
- [x] 7 unit tests (event filtering, concurrent pool, catch-up mode, resume)
- [ ] Verify scraper correctly archives contract events from testnet
- [ ] Verify no ledger events missed or duplicated
- [ ] Verify catch-up mode processes historical ledgers from start point
- [ ] Verify resume after restart picks up from last processed ledger