### PR TITLE
Add Figma design links for issues 80, 82, and 85

### DIFF
--- a/UI Design/PolyMarket-issue-80.txt
+++ b/UI Design/PolyMarket-issue-80.txt
@@ -1,0 +1,1 @@
+https://www.figma.com/design/qU6QZ2eMOXpHlDAD0ii9HD/PolyMarket-issue-80?node-id=0-1&p=f&t=DJIJt5euUAOgGu9Q-0

--- a/UI Design/PolyMarket-issue-82.txt
+++ b/UI Design/PolyMarket-issue-82.txt
@@ -1,0 +1,1 @@
+https://www.figma.com/design/WLv4pZGvsaN69WH2wruwmK/PolyMarket-issue-82?node-id=0-1&p=f&t=aIRA7HzJyJJZJumO-0

--- a/UI Design/PolyMarket-issue-85.txt
+++ b/UI Design/PolyMarket-issue-85.txt
@@ -1,0 +1,1 @@
+https://www.figma.com/design/g6yt7IymjOj821q6aXnGWk/PolyMarket-issue-85?node-id=0-1&p=f&t=o16nLaWfnqvCLVWv-0


### PR DESCRIPTION
Add Figma Design Links for Issues #80, #82, and #85

Overview

This PR adds reference files to the UI Design folder containing Figma design links for PolyMarket issues #80, #82, and #85. These files follow the same convention established in the folder for tracking UI design contributions alongside their corresponding GitHub issues.

Background

The UI Design folder serves as the central location for all high-fidelity design assets and references for Stellar PolyMarket. Previous design work (Issue #66) established the landing page design system — including the color system (orange for primary actions, green/red for market outcomes), typography, and responsive layout patterns. The designs in this PR build on that foundation and continue the visual direction of the project.

Changes

Added PolyMarket-issue-80.txt — Figma link for Issue #80
Added PolyMarket-issue-82.txt — Figma link for Issue #82
Added PolyMarket-issue-85.txt — Figma link for Issue #85
Design References

Issue #80 — PolyMarket-issue-80
Issue #82 — PolyMarket-issue-82
Issue #85 — PolyMarket-issue-85
Notes

No code changes included in this PR
Figma files require access — reviewers should request access if needed
These references are intended to guide frontend implementation for the respective issues
Closes #80, #82, #85

Want me to adjust anything — tone, structure, or add a checklist section?

Closes #80 
Closes #82 
Closes #85 