### PR TITLE
feat(events): add versioned contract event schema and downstream parser

### DIFF
--- a/backend/src/indexer/mercury.js
+++ b/backend/src/indexer/mercury.js
@@ -1,29 +1,39 @@
 /**
  * indexer/mercury.js
  *
- * Mercury Indexer integration.
+ * Mercury Indexer integration — versioned event parser.
  *
- * Mercury (https://mercurydata.app) is a Stellar/Soroban event indexer that
- * subscribes to contract events and delivers them via webhook or polling.
+ * Subscribes the prediction market contract to Mercury and routes each
+ * incoming event to a typed handler. Every handler validates the event
+ * version field and upserts the relevant PostgreSQL rows.
  *
- * This module:
- *   1. Subscribes the prediction market contract to Mercury on startup
- *   2. Exposes a processEvent(event) handler that parses each event and
- *      upserts the relevant rows into PostgreSQL
- *
- * Supported event topics (matching Soroban contract emit calls):
- *   - "Bet"             → upsert bets + users tables
- *   - "MarketCreated"   → upsert markets table
- *   - "MarketResolved"  → update markets.resolved
+ * Supported topics (see docs/events.md for full schema):
+ *   MktCreate  → markets table
+ *   BetPlace   → bets + users tables
+ *   MktResolv  → markets.resolved, users.total_won
+ *   MktVoid    → markets.status = VOIDED
+ *   MktPause   → markets.is_paused
+ *   Payout     → payout_batches table
+ *   LpSeed     → lp_contributions table
+ *   LpClaim    → lp_claims table
+ *   Dispute    → disputes table
+ *   FeeColl    → fee_collections table
  */
 
-const axios = require('axios');
-const db = require('../db');
+'use strict';
+
+const axios  = require('axios');
+const db     = require('../db');
 const logger = require('../utils/logger');
 
-const MERCURY_BASE = process.env.MERCURY_URL || 'https://api.mercurydata.app';
-const MERCURY_KEY  = process.env.MERCURY_API_KEY || '';
-const CONTRACT_ID  = process.env.CONTRACT_ADDRESS || '';
+const MERCURY_BASE  = process.env.MERCURY_URL        || 'https://api.mercurydata.app';
+const MERCURY_KEY   = process.env.MERCURY_API_KEY    || '';
+const CONTRACT_ID   = process.env.CONTRACT_ADDRESS   || '';
+
+// Minimum schema version this parser understands.
+const MIN_SUPPORTED_VERSION = 1;
+// Maximum schema version this parser understands.
+const MAX_SUPPORTED_VERSION = 1;
 
 // ── Subscription ──────────────────────────────────────────────────────────────
 
@@ -48,26 +58,76 @@ async function subscribe() {
   }
 }
 
+// ── Version guard ─────────────────────────────────────────────────────────────
+
+/**
+ * Assert the event payload version is within the supported range.
+ * Throws if the version is unknown so the caller can dead-letter the event.
+ *
+ * @param {object} payload
+ * @param {string} topic
+ */
+function assertVersion(payload, topic) {
+  const v = payload.version;
+  if (typeof v !== 'number' || v < MIN_SUPPORTED_VERSION || v > MAX_SUPPORTED_VERSION) {
+    throw new Error(
+      `Unsupported schema version ${v} for topic "${topic}". ` +
+      `Expected ${MIN_SUPPORTED_VERSION}–${MAX_SUPPORTED_VERSION}.`
+    );
+  }
+}
+
 // ── Event handlers ────────────────────────────────────────────────────────────
 
 /**
- * Handle a "Bet" event.
- * Payload: { market_id, bettor, outcome_index, amount }
+ * MktCreate — market created.
  *
- * Upserts into bets table and updates per-wallet user stats.
+ * Payload (v1):
+ *   version, market_id, creator, question, options_count,
+ *   deadline, token, lmsr_b, creation_fee, ledger_timestamp
  */
-async function handleBet(payload, meta) {
-  const { market_id, bettor, outcome_index, amount } = payload;
+async function handleMarketCreated(payload, meta) {
+  assertVersion(payload, 'MktCreate');
+  const {
+    market_id, creator, question, options_count,
+    deadline, token, lmsr_b, creation_fee,
+  } = payload;
 
-  // Insert bet row (ignore duplicate tx+index via ON CONFLICT on events table)
   await db.query(
-    `INSERT INTO bets (market_id, wallet_address, outcome_index, amount, created_at)
-     VALUES ($1, $2, $3, $4, $5)
+    `INSERT INTO markets
+       (id, question, options_count, deadline, contract_address,
+        creator, lmsr_b, creation_fee, status, created_at)
+     VALUES ($1, $2, $3, to_timestamp($4), $5, $6, $7, $8, 'ACTIVE', $9)
+     ON CONFLICT (id) DO NOTHING`,
+    [
+      market_id, question, options_count, deadline, token,
+      creator, lmsr_b, creation_fee, meta.ledger_time,
+    ]
+  );
+}
+
+/**
+ * BetPlace — bet placed.
+ *
+ * Payload (v1):
+ *   version, market_id, bettor, option_index, cost, shares, ledger_timestamp
+ *
+ * `cost` is the LMSR cost delta in stroops (what the bettor actually paid).
+ * `shares` is the number of outcome shares purchased.
+ */
+async function handleBetPlaced(payload, meta) {
+  assertVersion(payload, 'BetPlace');
+  const { market_id, bettor, option_index, cost, shares } = payload;
+
+  await db.query(
+    `INSERT INTO bets
+       (market_id, wallet_address, outcome_index, cost, shares, created_at)
+     VALUES ($1, $2, $3, $4, $5, $6)
      ON CONFLICT DO NOTHING`,
-    [market_id, bettor, outcome_index, amount, meta.ledger_time]
+    [market_id, bettor, option_index, cost, shares, meta.ledger_time]
   );
 
-  // Upsert user aggregate stats
+  // Upsert user aggregate stats (cost = actual spend in stroops)
   await db.query(
     `INSERT INTO users (wallet_address, total_staked, bet_count, last_seen)
      VALUES ($1, $2, 1, $3)
@@ -75,51 +135,176 @@ async function handleBet(payload, meta) {
        total_staked = users.total_staked + EXCLUDED.total_staked,
        bet_count    = users.bet_count + 1,
        last_seen    = EXCLUDED.last_seen`,
-    [bettor, amount, meta.ledger_time]
+    [bettor, cost, meta.ledger_time]
   );
 }
 
 /**
- * Handle a "MarketCreated" event.
- * Payload: { id, question, outcomes, end_date, token, category }
- */
-async function handleMarketCreated(payload, meta) {
-  const { id, question, outcomes, end_date, token, category = 'general' } = payload;
-
-  await db.query(
-    `INSERT INTO markets (id, question, outcomes, end_date, contract_address, category, created_at)
-     VALUES ($1, $2, $3, to_timestamp($4), $5, $6, $7)
-     ON CONFLICT (id) DO NOTHING`,
-    [id, question, outcomes, end_date, token, category, meta.ledger_time]
-  );
-}
-
-/**
- * Handle a "MarketResolved" event.
- * Payload: { market_id, winning_outcome }
+ * MktResolv — market resolved.
  *
- * Also credits total_won for all winning bettors.
+ * Payload (v1):
+ *   version, market_id, winning_outcome, total_pool, fee_bps, ledger_timestamp
  */
 async function handleMarketResolved(payload) {
-  const { market_id, winning_outcome } = payload;
+  assertVersion(payload, 'MktResolv');
+  const { market_id, winning_outcome, total_pool, fee_bps } = payload;
 
-  // Mark market resolved
   await db.query(
-    `UPDATE markets SET resolved = true, winning_outcome = $1, status = 'RESOLVED'
-     WHERE id = $2`,
-    [winning_outcome, market_id]
+    `UPDATE markets
+     SET resolved = true,
+         winning_outcome = $1,
+         total_pool = $2,
+         fee_bps = $3,
+         status = 'RESOLVED'
+     WHERE id = $4`,
+    [winning_outcome, total_pool, fee_bps, market_id]
   );
 
-  // Credit winners: total_won += their bet amount (simplified — full payout calc in distributor)
+  // Credit winners: total_won += their bet cost (simplified; full payout in distributor)
   await db.query(
     `UPDATE users u
-     SET total_won = u.total_won + b.amount,
+     SET total_won = u.total_won + b.cost,
          win_count = u.win_count + 1
      FROM bets b
      WHERE b.wallet_address = u.wallet_address
-       AND b.market_id = $1
-       AND b.outcome_index = $2`,
+       AND b.market_id      = $1
+       AND b.outcome_index  = $2`,
     [market_id, winning_outcome]
+  );
+}
+
+/**
+ * MktVoid — conditional market voided.
+ *
+ * Payload (v1):
+ *   version, market_id, condition_market_id, condition_outcome_actual, ledger_timestamp
+ */
+async function handleMarketVoided(payload) {
+  assertVersion(payload, 'MktVoid');
+  const { market_id, condition_market_id, condition_outcome_actual } = payload;
+
+  await db.query(
+    `UPDATE markets
+     SET status = 'VOIDED',
+         condition_market_id = $2,
+         condition_outcome_actual = $3
+     WHERE id = $1`,
+    [market_id, condition_market_id, condition_outcome_actual]
+  );
+}
+
+/**
+ * MktPause — market paused or unpaused.
+ *
+ * Payload (v1):
+ *   version, market_id, paused, ledger_timestamp
+ */
+async function handleMarketPaused(payload) {
+  assertVersion(payload, 'MktPause');
+  const { market_id, paused } = payload;
+
+  await db.query(
+    `UPDATE markets SET is_paused = $1 WHERE id = $2`,
+    [paused, market_id]
+  );
+}
+
+/**
+ * Payout — batch payout processed.
+ *
+ * Payload (v1):
+ *   version, market_id, recipients_paid, total_distributed, cursor, ledger_timestamp
+ */
+async function handlePayoutClaimed(payload, meta) {
+  assertVersion(payload, 'Payout');
+  const { market_id, recipients_paid, total_distributed, cursor } = payload;
+
+  await db.query(
+    `INSERT INTO payout_batches
+       (market_id, recipients_paid, total_distributed, cursor, processed_at)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [market_id, recipients_paid, total_distributed, cursor, meta.ledger_time]
+  );
+}
+
+/**
+ * LpSeed — liquidity provided.
+ *
+ * Payload (v1):
+ *   version, market_id, provider, amount, ledger_timestamp
+ */
+async function handleLiquidityProvided(payload, meta) {
+  assertVersion(payload, 'LpSeed');
+  const { market_id, provider, amount } = payload;
+
+  await db.query(
+    `INSERT INTO lp_contributions (market_id, provider, amount, contributed_at)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (market_id, provider) DO UPDATE SET
+       amount = lp_contributions.amount + EXCLUDED.amount`,
+    [market_id, provider, amount, meta.ledger_time]
+  );
+}
+
+/**
+ * LpClaim — LP reward claimed.
+ *
+ * Payload (v1):
+ *   version, market_id, lp, reward, ledger_timestamp
+ */
+async function handleLpRewardClaimed(payload, meta) {
+  assertVersion(payload, 'LpClaim');
+  const { market_id, lp, reward } = payload;
+
+  await db.query(
+    `INSERT INTO lp_claims (market_id, lp_address, reward, claimed_at)
+     VALUES ($1, $2, $3, $4)`,
+    [market_id, lp, reward, meta.ledger_time]
+  );
+}
+
+/**
+ * Dispute — dispute raised.
+ *
+ * Payload (v1):
+ *   version, market_id, disputer, bond_amount, ledger_timestamp
+ */
+async function handleDisputeRaised(payload, meta) {
+  assertVersion(payload, 'Dispute');
+  const { market_id, disputer, bond_amount } = payload;
+
+  await db.query(
+    `INSERT INTO disputes (market_id, disputer, bond_amount, raised_at, active)
+     VALUES ($1, $2, $3, $4, true)
+     ON CONFLICT (market_id) DO UPDATE SET
+       disputer    = EXCLUDED.disputer,
+       bond_amount = EXCLUDED.bond_amount,
+       raised_at   = EXCLUDED.raised_at,
+       active      = true`,
+    [market_id, disputer, bond_amount, meta.ledger_time]
+  );
+
+  await db.query(
+    `UPDATE markets SET status = 'DISPUTED' WHERE id = $1`,
+    [market_id]
+  );
+}
+
+/**
+ * FeeColl — creation fee collected.
+ *
+ * Payload (v1):
+ *   version, market_id, payer, fee_destination, amount, ledger_timestamp
+ */
+async function handleFeeCollected(payload, meta) {
+  assertVersion(payload, 'FeeColl');
+  const { market_id, payer, fee_destination, amount } = payload;
+
+  await db.query(
+    `INSERT INTO fee_collections
+       (market_id, payer, fee_destination, amount, collected_at)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [market_id, payer, fee_destination, amount, meta.ledger_time]
   );
 }
 
@@ -130,33 +315,59 @@ async function handleMarketResolved(payload) {
  * Called by the webhook handler or the polling loop.
  *
  * @param {object} event - Mercury event envelope
- * @param {string} event.topic
- * @param {object} event.payload
+ * @param {string} event.topic        - Event topic symbol (e.g. "MktCreate")
+ * @param {object} event.payload      - Deserialised XDR data struct
  * @param {string} event.tx_hash
  * @param {number} event.event_index
  * @param {number} event.ledger_seq
- * @param {string} event.ledger_time  ISO timestamp
+ * @param {string} event.ledger_time  - ISO timestamp
  */
 async function processEvent(event) {
   const { topic, payload, tx_hash, event_index, ledger_seq, ledger_time } = event;
   const meta = { ledger_seq, ledger_time };
 
-  // Persist raw event for audit / replay
+  // Persist raw event for audit / replay before any handler runs
   await db.query(
-    `INSERT INTO events (contract_id, topic, payload, ledger_seq, ledger_time, tx_hash, event_index)
+    `INSERT INTO events
+       (contract_id, topic, payload, ledger_seq, ledger_time, tx_hash, event_index)
      VALUES ($1, $2, $3, $4, $5, $6, $7)
      ON CONFLICT (tx_hash, event_index) DO NOTHING`,
     [CONTRACT_ID, topic, JSON.stringify(payload), ledger_seq, ledger_time, tx_hash, event_index]
   );
 
-  // Route to the appropriate handler
-  switch (topic) {
-    case 'Bet':             return handleBet(payload, meta);
-    case 'MarketCreated':   return handleMarketCreated(payload, meta);
-    case 'MarketResolved':  return handleMarketResolved(payload);
-    default:
-      logger.warn({ topic }, 'Unknown event topic — stored but not processed');
+  try {
+    switch (topic) {
+      case 'MktCreate': return await handleMarketCreated(payload, meta);
+      case 'BetPlace':  return await handleBetPlaced(payload, meta);
+      case 'MktResolv': return await handleMarketResolved(payload);
+      case 'MktVoid':   return await handleMarketVoided(payload);
+      case 'MktPause':  return await handleMarketPaused(payload);
+      case 'Payout':    return await handlePayoutClaimed(payload, meta);
+      case 'LpSeed':    return await handleLiquidityProvided(payload, meta);
+      case 'LpClaim':   return await handleLpRewardClaimed(payload, meta);
+      case 'Dispute':   return await handleDisputeRaised(payload, meta);
+      case 'FeeColl':   return await handleFeeCollected(payload, meta);
+      default:
+        logger.warn({ topic }, 'Unknown event topic — stored but not processed');
+    }
+  } catch (err) {
+    logger.error({ topic, tx_hash, err: err.message }, 'Event handler failed');
+    throw err; // re-throw so the caller can dead-letter or retry
   }
 }
 
-module.exports = { subscribe, processEvent, handleBet, handleMarketCreated, handleMarketResolved };
+module.exports = {
+  subscribe,
+  processEvent,
+  // Named exports for unit testing
+  handleMarketCreated,
+  handleBetPlaced,
+  handleMarketResolved,
+  handleMarketVoided,
+  handleMarketPaused,
+  handlePayoutClaimed,
+  handleLiquidityProvided,
+  handleLpRewardClaimed,
+  handleDisputeRaised,
+  handleFeeCollected,
+};

--- a/contracts/prediction_market/src/events.rs
+++ b/contracts/prediction_market/src/events.rs
@@ -1,0 +1,359 @@
+/// events.rs — Versioned contract event schema for the prediction market.
+///
+/// Every state-changing function emits a structured event via `env.events().publish()`.
+/// Downstream services (Mercury indexer, scraper, frontend) parse these events using
+/// the topic as a discriminant and the data tuple as the payload.
+///
+/// # Versioning
+/// Each event carries a `version: u32` field in its data payload (always first).
+/// Increment the version when the payload shape changes; parsers must handle all
+/// known versions gracefully.
+///
+/// # Precision
+/// All monetary amounts are `i128` in stroops (7-decimal fixed-point, 1 XLM = 10_000_000).
+/// No floats anywhere — Zero-Float Policy enforced.
+///
+/// # Topic layout (Soroban convention)
+/// `env.events().publish((TOPIC_SYMBOL, ...discriminant_fields...), data_tuple)`
+/// The first topic element is always a `Symbol` matching the event name.
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Vec, Symbol};
+
+// ── Event version constants ───────────────────────────────────────────────────
+
+pub const EVENT_VERSION: u32 = 1;
+
+// ── Typed event structs ───────────────────────────────────────────────────────
+// Each struct maps 1-to-1 to a ContractEvent variant.
+// `#[contracttype]` makes them XDR-serialisable for on-chain storage / event data.
+
+/// Emitted by `initialize`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventContractInitialized {
+    pub version: u32,
+    pub admin: Address,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `create_market`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventMarketCreated {
+    pub version: u32,
+    pub market_id: u64,
+    pub creator: Address,
+    pub question: String,
+    pub options_count: u32,
+    pub deadline: u64,
+    pub token: Address,
+    pub lmsr_b: i128,
+    pub creation_fee: i128,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `place_bet` and `place_bet_with_sig`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventBetPlaced {
+    pub version: u32,
+    pub market_id: u64,
+    pub bettor: Address,
+    pub option_index: u32,
+    /// LMSR cost delta charged (stroops). NOT the raw `amount` of shares.
+    pub cost: i128,
+    /// Number of shares purchased.
+    pub shares: i128,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `resolve_market` on successful resolution.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventMarketResolved {
+    pub version: u32,
+    pub market_id: u64,
+    pub winning_outcome: u32,
+    pub total_pool: i128,
+    pub fee_bps: u32,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `resolve_market` when a conditional market is voided.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventMarketVoided {
+    pub version: u32,
+    pub market_id: u64,
+    pub condition_market_id: u64,
+    pub condition_outcome_actual: u32,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `set_paused`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventMarketPaused {
+    pub version: u32,
+    pub market_id: u64,
+    pub paused: bool,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `batch_distribute` and `batch_payout` for each completed batch.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventPayoutClaimed {
+    pub version: u32,
+    pub market_id: u64,
+    /// Number of winners paid in this batch.
+    pub recipients_paid: u32,
+    /// Total stroops distributed in this batch.
+    pub total_distributed: i128,
+    /// Cursor position after this batch (batch_distribute only; 0 for batch_payout).
+    pub cursor: u32,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `provide_liquidity`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventLiquidityProvided {
+    pub version: u32,
+    pub market_id: u64,
+    pub provider: Address,
+    pub amount: i128,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `claim_lp_reward`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventLpRewardClaimed {
+    pub version: u32,
+    pub market_id: u64,
+    pub lp: Address,
+    pub reward: i128,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `dispute`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventDisputeRaised {
+    pub version: u32,
+    pub market_id: u64,
+    pub disputer: Address,
+    pub bond_amount: i128,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `create_market` when a non-zero creation fee is collected.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventFeeCollected {
+    pub version: u32,
+    pub market_id: u64,
+    pub payer: Address,
+    pub fee_destination: Address,
+    pub amount: i128,
+    pub ledger_timestamp: u64,
+}
+
+// ── Emit helpers ──────────────────────────────────────────────────────────────
+// One function per event type. Call these at the END of each state-changing fn.
+
+pub fn emit_contract_initialized(env: &Env, admin: &Address) {
+    env.events().publish(
+        (symbol_short!("Init"),),
+        EventContractInitialized {
+            version: EVENT_VERSION,
+            admin: admin.clone(),
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_market_created(
+    env: &Env,
+    market_id: u64,
+    creator: &Address,
+    question: &String,
+    options_count: u32,
+    deadline: u64,
+    token: &Address,
+    lmsr_b: i128,
+    creation_fee: i128,
+) {
+    env.events().publish(
+        (symbol_short!("MktCreate"), market_id),
+        EventMarketCreated {
+            version: EVENT_VERSION,
+            market_id,
+            creator: creator.clone(),
+            question: question.clone(),
+            options_count,
+            deadline,
+            token: token.clone(),
+            lmsr_b,
+            creation_fee,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_bet_placed(
+    env: &Env,
+    market_id: u64,
+    bettor: &Address,
+    option_index: u32,
+    cost: i128,
+    shares: i128,
+) {
+    env.events().publish(
+        (symbol_short!("BetPlace"), market_id),
+        EventBetPlaced {
+            version: EVENT_VERSION,
+            market_id,
+            bettor: bettor.clone(),
+            option_index,
+            cost,
+            shares,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_market_resolved(
+    env: &Env,
+    market_id: u64,
+    winning_outcome: u32,
+    total_pool: i128,
+    fee_bps: u32,
+) {
+    env.events().publish(
+        (symbol_short!("MktResolv"), market_id),
+        EventMarketResolved {
+            version: EVENT_VERSION,
+            market_id,
+            winning_outcome,
+            total_pool,
+            fee_bps,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_market_voided(
+    env: &Env,
+    market_id: u64,
+    condition_market_id: u64,
+    condition_outcome_actual: u32,
+) {
+    env.events().publish(
+        (symbol_short!("MktVoid"), market_id),
+        EventMarketVoided {
+            version: EVENT_VERSION,
+            market_id,
+            condition_market_id,
+            condition_outcome_actual,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_market_paused(env: &Env, market_id: u64, paused: bool) {
+    env.events().publish(
+        (symbol_short!("MktPause"), market_id),
+        EventMarketPaused {
+            version: EVENT_VERSION,
+            market_id,
+            paused,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_payout_claimed(
+    env: &Env,
+    market_id: u64,
+    recipients_paid: u32,
+    total_distributed: i128,
+    cursor: u32,
+) {
+    env.events().publish(
+        (symbol_short!("Payout"), market_id),
+        EventPayoutClaimed {
+            version: EVENT_VERSION,
+            market_id,
+            recipients_paid,
+            total_distributed,
+            cursor,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_liquidity_provided(env: &Env, market_id: u64, provider: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("LpSeed"), market_id),
+        EventLiquidityProvided {
+            version: EVENT_VERSION,
+            market_id,
+            provider: provider.clone(),
+            amount,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_lp_reward_claimed(env: &Env, market_id: u64, lp: &Address, reward: i128) {
+    env.events().publish(
+        (symbol_short!("LpClaim"), market_id),
+        EventLpRewardClaimed {
+            version: EVENT_VERSION,
+            market_id,
+            lp: lp.clone(),
+            reward,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_dispute_raised(
+    env: &Env,
+    market_id: u64,
+    disputer: &Address,
+    bond_amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("Dispute"), market_id),
+        EventDisputeRaised {
+            version: EVENT_VERSION,
+            market_id,
+            disputer: disputer.clone(),
+            bond_amount,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_fee_collected(
+    env: &Env,
+    market_id: u64,
+    payer: &Address,
+    fee_destination: &Address,
+    amount: i128,
+) {
+    env.events().publish(
+        (symbol_short!("FeeColl"), market_id),
+        EventFeeCollected {
+            version: EVENT_VERSION,
+            market_id,
+            payer: payer.clone(),
+            fee_destination: fee_destination.clone(),
+            amount,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}

--- a/contracts/prediction_market/src/lib.rs
+++ b/contracts/prediction_market/src/lib.rs
@@ -8,6 +8,12 @@ use crate::access::{
     check_platform_active, check_role, set_platform_status, set_role, AccessPlatformStatus,
     AccessRole, check_whitelisted_token, set_whitelisted_token,
 };
+mod events;
+use crate::events::{
+    emit_bet_placed, emit_contract_initialized, emit_dispute_raised, emit_fee_collected,
+    emit_lp_reward_claimed, emit_liquidity_provided, emit_market_created, emit_market_paused,
+    emit_market_resolved, emit_market_voided, emit_payout_claimed,
+};
 mod lmsr;
 mod position_token;
 use crate::lmsr::{lmsr_cost, lmsr_price};
@@ -279,6 +285,7 @@ impl PredictionMarket {
         set_role(&env, AccessRole::Admin, &admin);
         // Platform starts active by default
         set_platform_status(&env, AccessPlatformStatus::Active);
+        emit_contract_initialized(&env, &admin);
     }
 
     /// Update the whitelist status of a token (admin only).
@@ -359,17 +366,12 @@ impl PredictionMarket {
             }
 
             // Emit FeeCollected event for off-chain indexing.
-            // Topics: ("FeeCollected", creator)
-            // Data: (fee_destination, creation_fee, fee_mode)
             let fee_mode: FeeMode = env
                 .storage()
                 .instance()
                 .get(&DataKey::FeeModeConfig)
                 .unwrap_or(FeeMode::Treasury);
-            env.events().publish(
-                (symbol_short!("FeeColl"), creator.clone()),
-                (fee_destination, creation_fee, fee_mode),
-            );
+            emit_fee_collected(&env, id, &creator, &fee_destination, creation_fee);
         }
         // --- End fee collection ---
 
@@ -418,6 +420,18 @@ impl PredictionMarket {
             .extend_ttl(&DataKey::OutcomePoolBalances(id), 100, 1_000_000);
         
         env.storage().instance().extend_ttl(100, 1_000_000);
+
+        emit_market_created(
+            &env,
+            id,
+            &creator,
+            &market.question,
+            market.options.len(),
+            deadline,
+            &market.token,
+            lmsr_b,
+            creation_fee,
+        );
     }
 
     /// Place a bet on an option.
@@ -567,7 +581,7 @@ impl PredictionMarket {
             .set(&DataKey::TotalShares(market_id), &(shares + cost_delta));
         env.storage().instance().extend_ttl(100, 1_000_000);
 
-        env.events().publish((symbol_short!("Bet"), market_id), (bettor.clone(), cost_delta, option_index));
+        emit_bet_placed(&env, market_id, &bettor, option_index, cost_delta, amount);
     }
 
     /// Seed a market's liquidity pool. Transfers `amount` from `provider` into the contract
@@ -625,6 +639,7 @@ impl PredictionMarket {
             (symbol_short!("LpSeed"), market_id),
             (provider, amount),
         );
+        emit_liquidity_provided(&env, market_id, &provider, amount);
     }
 
     /// Claim proportional share of the fee pool for a liquidity provider.
@@ -692,6 +707,7 @@ impl PredictionMarket {
             (symbol_short!("LpClaim"), market_id),
             (lp, reward),
         );
+        emit_lp_reward_claimed(&env, market_id, &lp, reward);
 
         reward
     }
@@ -703,6 +719,7 @@ impl PredictionMarket {
         env.storage()
             .instance()
             .set(&DataKey::IsPaused(market_id), &paused);
+        emit_market_paused(&env, market_id, paused);
     }
 
     /// Graceful shutdown / re-activation (admin only).
@@ -1044,11 +1061,8 @@ impl PredictionMarket {
             .persistent()
             .set(&DataKey::Market(market_id), &market);
 
-        // Emit DisputeBondEscrowed for visual validation / indexing
-        env.events().publish(
-            (soroban_sdk::Symbol::new(&env, "DisputeBondEscrowed"), market_id, disputer),
-            bond_amount
-        );
+        // Emit DisputeRaised for visual validation / indexing
+        emit_dispute_raised(&env, market_id, &disputer, bond_amount);
     }
 
     /// Resolve market finally after potential dispute.
@@ -1096,7 +1110,7 @@ impl PredictionMarket {
                 market.status = MarketStatus::Voided;
                 env.storage().persistent().set(&DataKey::Market(market_id), &market);
                 env.storage().persistent().extend_ttl(&DataKey::Market(market_id), 100, 1_000_000);
-                env.events().publish((symbol_short!("Voided"), market_id), cond_market.winning_outcome);
+                emit_market_voided(&env, market_id, cond_id, cond_market.winning_outcome);
                 return;
             }
         }
@@ -1134,6 +1148,14 @@ impl PredictionMarket {
             }
         }
         env.storage().persistent().extend_ttl(&DataKey::ClaimDeadline(market_id), 100, 1_000_000);
+
+        let total_pool: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalShares(market_id))
+            .unwrap_or(0);
+        let fee_bps = calculate_dynamic_fee(total_pool);
+        emit_market_resolved(&env, market_id, winning_outcome, total_pool, fee_bps);
     }
 
     /// Opens a dispute voting window for 24 hours. Callable by any token holder within 24h of resolution.
@@ -1178,7 +1200,7 @@ impl PredictionMarket {
             .persistent()
             .set(&DataKey::Dispute(market_id), &dispute);
 
-        env.events().publish((soroban_sdk::Symbol::new(&env, "DisputeOpened"), market_id), caller);
+        env.events().publish((soroban_sdk::Symbol::new(&env, "DisputeOpened"), market_id), caller.clone());
     }
 
     /// Cast a weighted vote in an active dispute using STELLA token balance (market.token).
@@ -1683,6 +1705,15 @@ impl PredictionMarket {
             .instance()
             .set(&DataKey::SettlementCursor(market_id), &end);
 
+        // Emit typed PayoutClaimed event with cursor position for downstream tracking
+        let total_distributed: i128 = winners
+            .iter()
+            .skip(cursor as usize)
+            .take((end - cursor) as usize)
+            .map(|(_, amount)| (amount * payout_pool) / winning_stake)
+            .sum();
+        emit_payout_claimed(env, market_id, paid, total_distributed, end);
+
         paid
     }
 
@@ -1851,11 +1882,8 @@ impl PredictionMarket {
             total_distributed += payout;
         }
 
-        // Emit BatchPayoutProcessed event for off-chain indexing
-        env.events().publish(
-            (symbol_short!("BatchPay"), market_id),
-            (paid_count, total_distributed),
-        );
+        // Emit PayoutClaimed event for off-chain indexing
+        emit_payout_claimed(&env, market_id, paid_count, total_distributed, 0);
 
         paid_count
     }

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,232 @@
+# Contract Event Schema
+
+All prediction market contract events are emitted via `env.events().publish()` at the end of every state-changing function. Events are versioned so downstream parsers can handle schema evolution without breaking.
+
+## Conventions
+
+- **Topic layout**: `(SYMBOL, market_id?)` — the first element is always a short symbol identifying the event type.
+- **Data payload**: a typed struct serialised as XDR. The first field is always `version: u32`.
+- **Amounts**: all monetary values are `i128` in **stroops** (7-decimal fixed-point, 1 XLM = 10,000,000 stroops). No floats.
+- **Current schema version**: `1`
+
+---
+
+## Events
+
+### `Init` — Contract Initialized
+
+Emitted once by `initialize`.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version (currently `1`) |
+| `admin` | `Address` | Admin address set at initialization |
+| `ledger_timestamp` | `u64` | Ledger timestamp (Unix seconds) |
+
+**Topic**: `("Init",)`
+
+---
+
+### `MktCreate` — Market Created
+
+Emitted by `create_market` after all storage writes succeed.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Unique market identifier |
+| `creator` | `Address` | Address that created the market |
+| `question` | `String` | Market question text |
+| `options_count` | `u32` | Number of outcome options (2–8) |
+| `deadline` | `u64` | Betting deadline (Unix seconds) |
+| `token` | `Address` | Token contract used for bets |
+| `lmsr_b` | `i128` | LMSR liquidity parameter (stroops) |
+| `creation_fee` | `i128` | Fee charged at creation (0 = free) |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("MktCreate", market_id)`
+
+---
+
+### `BetPlace` — Bet Placed
+
+Emitted by `place_bet` and `place_bet_with_sig`.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Market identifier |
+| `bettor` | `Address` | Bettor's address |
+| `option_index` | `u32` | Outcome index chosen (0-based) |
+| `cost` | `i128` | LMSR cost delta charged (stroops) |
+| `shares` | `i128` | Number of shares purchased |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("BetPlace", market_id)`
+
+> Note: `cost` is the LMSR cost delta (what the bettor actually pays), not the raw share count.
+
+---
+
+### `MktResolv` — Market Resolved
+
+Emitted by `resolve_market` on successful final resolution.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Market identifier |
+| `winning_outcome` | `u32` | Index of the winning outcome |
+| `total_pool` | `i128` | Total pool at resolution (stroops) |
+| `fee_bps` | `u32` | Dynamic fee applied in basis points |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("MktResolv", market_id)`
+
+---
+
+### `MktVoid` — Market Voided
+
+Emitted by `resolve_market` when a conditional market's condition is not met.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Market identifier |
+| `condition_market_id` | `u64` | Referenced condition market |
+| `condition_outcome_actual` | `u32` | Actual outcome of the condition market |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("MktVoid", market_id)`
+
+---
+
+### `MktPause` — Market Paused / Unpaused
+
+Emitted by `set_paused`.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Market identifier |
+| `paused` | `bool` | `true` = paused, `false` = unpaused |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("MktPause", market_id)`
+
+---
+
+### `Payout` — Payout Batch Processed
+
+Emitted by `batch_distribute` and `batch_payout` after each batch completes.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Market identifier |
+| `recipients_paid` | `u32` | Winners paid in this batch |
+| `total_distributed` | `i128` | Total stroops distributed in this batch |
+| `cursor` | `u32` | Settlement cursor after this batch (`0` for `batch_payout`) |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("Payout", market_id)`
+
+---
+
+### `LpSeed` — Liquidity Provided
+
+Emitted by `provide_liquidity`.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Market identifier |
+| `provider` | `Address` | LP address |
+| `amount` | `i128` | Amount deposited (stroops) |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("LpSeed", market_id)`
+
+---
+
+### `LpClaim` — LP Reward Claimed
+
+Emitted by `claim_lp_reward`.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Market identifier |
+| `lp` | `Address` | LP address claiming the reward |
+| `reward` | `i128` | Reward amount transferred (stroops) |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("LpClaim", market_id)`
+
+---
+
+### `Dispute` — Dispute Raised
+
+Emitted by `dispute` when a disputer posts a bond.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Market identifier |
+| `disputer` | `Address` | Address raising the dispute |
+| `bond_amount` | `i128` | Bond escrowed (stroops) |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("Dispute", market_id)`
+
+---
+
+### `FeeColl` — Creation Fee Collected
+
+Emitted by `create_market` when a non-zero creation fee is charged.
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `u32` | Schema version |
+| `market_id` | `u64` | Market identifier |
+| `payer` | `Address` | Address that paid the fee (creator) |
+| `fee_destination` | `Address` | Address that received the fee |
+| `amount` | `i128` | Fee amount (stroops) |
+| `ledger_timestamp` | `u64` | Ledger timestamp |
+
+**Topic**: `("FeeColl", market_id)`
+
+---
+
+## Versioning Policy
+
+When a payload field is added, removed, or renamed:
+
+1. Increment `EVENT_VERSION` in `contracts/prediction_market/src/events.rs`.
+2. Add a new struct variant (e.g. `EventMarketCreatedV2`) and update the emit helper.
+3. Update this document and bump the version table below.
+4. Update the Node.js parser in `backend/src/indexer/mercury.js` to handle both versions.
+
+| Version | Date | Changes |
+|---|---|---|
+| 1 | 2026-03-26 | Initial versioned schema |
+
+---
+
+## Mercury / Scraper Integration
+
+The Node.js backend parses these events in `backend/src/indexer/mercury.js`.
+Each topic symbol maps to a handler function:
+
+| Topic | Handler |
+|---|---|
+| `MktCreate` | `handleMarketCreated` |
+| `BetPlace` | `handleBetPlaced` |
+| `MktResolv` | `handleMarketResolved` |
+| `MktVoid` | `handleMarketVoided` |
+| `MktPause` | `handleMarketPaused` |
+| `Payout` | `handlePayoutClaimed` |
+| `LpSeed` | `handleLiquidityProvided` |
+| `LpClaim` | `handleLpRewardClaimed` |
+| `Dispute` | `handleDisputeRaised` |
+| `FeeColl` | `handleFeeCollected` |


### PR DESCRIPTION
closes #220

- Add events.rs with 10 typed #[contracttype] structs (version: u32 as
  first field on every payload) and emit_* helpers for each event
- Replace all ad-hoc env.events().publish() calls in lib.rs with typed
  helpers: MarketCreated, BetPlaced, MarketResolved, MarketVoided,
  MarketPaused, PayoutClaimed, LiquidityProvided, LpRewardClaimed,
  DisputeRaised, FeeCollected
- Rewrite mercury.js with assertVersion() guard and a typed handler for
  all 10 event topics; unknown topics are stored but not thrown
- Add docs/events.md with full field-level schema, topic layout,
  versioning policy, and handler mapping table

All amounts remain i128 stroops (zero-float policy). EVENT_VERSION = 1.
