### PR TITLE
feat: implement configurable platform fee rate in basis points (#395)

### DIFF
--- a/contracts/prediction_market/Cargo.lock
+++ b/contracts/prediction_market/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "zeroize",
 ]
@@ -84,7 +84,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "paste",
@@ -158,7 +158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -174,6 +174,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,9 +193,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -296,7 +314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -535,13 +553,13 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -566,7 +584,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -596,7 +614,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -649,7 +667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -787,6 +805,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -961,7 +988,11 @@ dependencies = [
 name = "prediction-market"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "base64ct",
+ "ed25519-dalek",
+ "proptest",
+ "soroban-sdk 21.7.7",
+ "soroban-sdk 25.3.0",
 ]
 
 [[package]]
@@ -993,6 +1024,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "unarray",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,8 +1053,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1019,7 +1073,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1029,6 +1093,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1179,7 +1258,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1239,7 +1318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1250,14 +1329,44 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
+version = "21.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f57a68ef8777e28e274de0f3a88ad9a5a41d9a2eb461b4dd800b086f0e83b80"
+dependencies = [
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "soroban-builtin-sdk-macros"
 version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7192e3a5551a7aeee90d2110b11b615798e81951fd8c8293c87ea7f88b0168f5"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "soroban-env-common"
+version = "21.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1c89463835fe6da996318156d39f424b4f167c725ec692e5a7a2d4e694b3d"
+dependencies = [
+ "crate-git-revision",
+ "ethnum",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "soroban-env-macros 21.2.1",
+ "soroban-wasmi",
+ "static_assertions",
+ "stellar-xdr 21.2.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1272,11 +1381,21 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "soroban-env-macros",
+ "soroban-env-macros 25.0.1",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr",
+ "stellar-xdr 25.0.0",
  "wasmparser",
+]
+
+[[package]]
+name = "soroban-env-guest"
+version = "21.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bfb2536811045d5cd0c656a324cbe9ce4467eb734c7946b74410d90dea5d0ce"
+dependencies = [
+ "soroban-env-common 21.2.1",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1285,8 +1404,40 @@ version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2334ba1cfe0a170ab744d96db0b4ca86934de9ff68187ceebc09dc342def55"
 dependencies = [
- "soroban-env-common",
+ "soroban-env-common 25.0.1",
  "static_assertions",
+]
+
+[[package]]
+name = "soroban-env-host"
+version = "21.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7a32c28f281c423189f1298960194f0e0fc4eeb72378028171e556d8cd6160"
+dependencies = [
+ "curve25519-dalek",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "generic-array",
+ "getrandom",
+ "hex-literal",
+ "hmac",
+ "k256",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "p256",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "sec1",
+ "sha2",
+ "sha3",
+ "soroban-builtin-sdk-macros 21.2.1",
+ "soroban-env-common 21.2.1",
+ "soroban-wasmi",
+ "static_assertions",
+ "stellar-strkey 0.0.8",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1313,13 +1464,13 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros",
- "soroban-env-common",
+ "soroban-builtin-sdk-macros 25.0.1",
+ "soroban-env-common 25.0.1",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
@@ -1328,17 +1479,46 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "25.0.1"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a989167512e3592d455b1e204d703cfe578a36672a77ed2f9e6f7e1bbfd9cc5c"
+checksum = "242926fe5e0d922f12d3796cd7cd02dd824e5ef1caa088f45fce20b618309f64"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr",
+ "stellar-xdr 21.2.0",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "soroban-env-macros"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a989167512e3592d455b1e204d703cfe578a36672a77ed2f9e6f7e1bbfd9cc5c"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "stellar-xdr 25.0.0",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "soroban-ledger-snapshot"
+version = "21.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6edf92749fd8399b417192d301c11f710b9cdce15789a3d157785ea971576fa"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "soroban-env-common 21.2.1",
+ "soroban-env-host 21.2.1",
+ "thiserror",
 ]
 
 [[package]]
@@ -1350,9 +1530,27 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "soroban-env-common",
- "soroban-env-host",
+ "soroban-env-common 25.0.1",
+ "soroban-env-host 25.0.1",
  "thiserror",
+]
+
+[[package]]
+name = "soroban-sdk"
+version = "21.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcdf04484af7cc731a7a48ad1d9f5f940370edeea84734434ceaf398a6b862e"
+dependencies = [
+ "bytes-lit",
+ "rand 0.8.5",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "soroban-env-guest 21.2.1",
+ "soroban-env-host 21.2.1",
+ "soroban-ledger-snapshot 21.7.7",
+ "soroban-sdk-macros 21.7.7",
+ "stellar-strkey 0.0.8",
 ]
 
 [[package]]
@@ -1367,16 +1565,36 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
- "soroban-env-guest",
- "soroban-env-host",
- "soroban-ledger-snapshot",
- "soroban-sdk-macros",
+ "soroban-env-guest 25.0.1",
+ "soroban-env-host 25.0.1",
+ "soroban-ledger-snapshot 25.3.0",
+ "soroban-sdk-macros 25.3.0",
  "stellar-strkey 0.0.16",
  "visibility",
+]
+
+[[package]]
+name = "soroban-sdk-macros"
+version = "21.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0974e413731aeff2443f2305b344578b3f1ffd18335a7ba0f0b5d2eb4e94c9ce"
+dependencies = [
+ "crate-git-revision",
+ "darling 0.20.11",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "sha2",
+ "soroban-env-common 21.2.1",
+ "soroban-spec 21.7.7",
+ "soroban-spec-rust 21.7.7",
+ "stellar-xdr 21.2.0",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1387,16 +1605,28 @@ checksum = "dec603a62a90abdef898f8402471a24d8b58a0043b9a998ed6a607a19a5dabe1"
 dependencies = [
  "darling 0.20.11",
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "macro-string",
  "proc-macro2",
  "quote",
  "sha2",
- "soroban-env-common",
- "soroban-spec",
- "soroban-spec-rust",
- "stellar-xdr",
+ "soroban-env-common 25.0.1",
+ "soroban-spec 25.3.0",
+ "soroban-spec-rust 25.3.0",
+ "stellar-xdr 25.0.0",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "soroban-spec"
+version = "21.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2c70b20e68cae3ef700b8fa3ae29db1c6a294b311fba66918f90cb8f9fd0a1a"
+dependencies = [
+ "base64 0.13.1",
+ "stellar-xdr 21.2.0",
+ "thiserror",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1405,11 +1635,27 @@ version = "25.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24718fac3af127fc6910eb6b1d3ccd8403201b6ef0aca73b5acabe4bc3dd42ed"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "sha2",
- "stellar-xdr",
+ "stellar-xdr 25.0.0",
  "thiserror",
  "wasmparser",
+]
+
+[[package]]
+name = "soroban-spec-rust"
+version = "21.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2dafbde981b141b191c6c036abc86097070ddd6eaaa33b273701449501e43d3"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "soroban-spec 21.7.7",
+ "stellar-xdr 21.2.0",
+ "syn 2.0.117",
+ "thiserror",
 ]
 
 [[package]]
@@ -1422,8 +1668,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "soroban-spec",
- "stellar-xdr",
+ "soroban-spec 25.3.0",
+ "stellar-xdr 25.0.0",
  "syn 2.0.117",
  "thiserror",
 ]
@@ -1471,6 +1717,17 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stellar-strkey"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd"
+dependencies = [
+ "base32",
+ "crate-git-revision",
+ "thiserror",
+]
+
+[[package]]
+name = "stellar-strkey"
 version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
@@ -1492,12 +1749,27 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
+version = "21.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2675a71212ed39a806e415b0dbf4702879ff288ec7f5ee996dda42a135512b50"
+dependencies = [
+ "base64 0.13.1",
+ "crate-git-revision",
+ "escape-bytes",
+ "hex",
+ "serde",
+ "serde_with",
+ "stellar-strkey 0.0.8",
+]
+
+[[package]]
+name = "stellar-xdr"
 version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d20dafed80076b227d4b17c0c508a4bbc4d5e4c3d4c1de7cd42242df4b1eaf"
 dependencies = [
  "arbitrary",
- "base64",
+ "base64 0.22.1",
  "cfg_eval",
  "crate-git-revision",
  "escape-bytes",
@@ -1599,6 +1871,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/contracts/prediction_market/Cargo.toml
+++ b/contracts/prediction_market/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 soroban-sdk = { version = "21.7.6", features = ["alloc"] }
 base64ct = "=1.5.0"
-ed25519-dalek = "=2.1.0"
+ed25519-dalek = "=2.1.1"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.3.0", features = ["testutils"] }

--- a/contracts/prediction_market/src/events.rs
+++ b/contracts/prediction_market/src/events.rs
@@ -148,6 +148,16 @@ pub struct EventDisputeRaised {
     pub ledger_timestamp: u64,
 }
 
+/// Emitted by `set_fee_rate` on every successful update.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventFeeRateUpdated {
+    pub version: u32,
+    pub old_rate_bps: u32,
+    pub new_rate_bps: u32,
+    pub ledger_timestamp: u64,
+}
+
 /// Emitted by `create_market` when a non-zero creation fee is collected.
 #[contracttype]
 #[derive(Clone)]
@@ -333,6 +343,18 @@ pub fn emit_dispute_raised(
             market_id,
             disputer: disputer.clone(),
             bond_amount,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_fee_rate_updated(env: &Env, old_rate_bps: u32, new_rate_bps: u32) {
+    env.events().publish(
+        (symbol_short!("FeeRateUp"),),
+        EventFeeRateUpdated {
+            version: EVENT_VERSION,
+            old_rate_bps,
+            new_rate_bps,
             ledger_timestamp: env.ledger().timestamp(),
         },
     );

--- a/contracts/prediction_market/src/lib.rs
+++ b/contracts/prediction_market/src/lib.rs
@@ -3,8 +3,7 @@
 #[cfg(test)]
 use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token, Address, BytesN, Env, Map, String, Vec,
-    contract, contractimpl, contracttype, symbol_short, token, vec, Address, Env, String, Vec, Map, IntoVal,
+    contract, contractimpl, contracttype, symbol_short, token, vec, Address, BytesN, Env, Map, String, Vec, IntoVal,
 };
 mod access;
 use crate::access::{
@@ -17,8 +16,8 @@ use crate::checked_math::{cadd, csub, cmul, cdiv, cmuldiv};
 mod events;
 use crate::events::{
     emit_bet_placed, emit_contract_initialized, emit_dispute_raised, emit_fee_collected,
-    emit_lp_reward_claimed, emit_liquidity_provided, emit_market_created, emit_market_paused,
-    emit_market_resolved, emit_market_voided, emit_payout_claimed,
+    emit_fee_rate_updated, emit_lp_reward_claimed, emit_liquidity_provided, emit_market_created,
+    emit_market_paused, emit_market_resolved, emit_market_voided, emit_payout_claimed,
 };
 mod lmsr;
 mod position_token;
@@ -67,6 +66,15 @@ pub const DISPUTE_WINDOW: u64 = 86_400;
 /// Threshold: 535_000 / 2 = 267_500 ledgers (~37 days)
 /// Extend to: 535_000 ledgers (~74 days)
 pub const LEDGER_TTL_EXTEND: u32 = 535_000;
+
+/// Reads the stored platform fee rate in basis points from Instance storage.
+/// Falls back to 300 bps (3%) if not set (e.g., before first initialize).
+fn read_fee_rate_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::FeeRateBps)
+        .unwrap_or(300u32)
+}
 
 /// Calculates dynamic platform fee in Basis Points (BPS).
 /// Pure function: O(1) time complexity, O(1) space complexity.
@@ -125,6 +133,60 @@ pub enum DataKey {
     Busy,
     /// Persistent: individual pool balance per outcome (market_id, outcome_index)
     OutcomePool(u64, u32),
+    /// Legacy admin key in Instance storage
+    Admin,
+    /// Liquidity provider contributions per market
+    LpContribution(u64),
+    /// LP fee pool per market
+    LpFeePool(u64),
+    /// User's total cost paid into a market (for refunds)
+    UserCost(u64, Address),
+    /// User position map per market (legacy)
+    UserPosition(u64),
+    /// LMSR b parameter per market
+    LmsrB(u64),
+    /// LMSR outcome shares per market
+    OutcomeShares(u64),
+    /// Market creation fee
+    CreationFee,
+    /// Fee destination address
+    FeeDestination,
+    /// Fee mode configuration
+    FeeModeConfig,
+    /// Minimum bet amount
+    MinBetAmount,
+    /// Maximum bet amount
+    MaxBetAmount,
+    /// Fee split configuration
+    FeeSplitConfig,
+    /// Treasury address for fee splits
+    TreasuryAddress,
+    /// LP pool address for fee splits
+    LPAddress,
+    /// Burn address for fee splits
+    BurnAddress,
+    /// Nonce for gasless bets
+    Nonce(Address),
+    /// Claim deadline timestamp per market
+    ClaimDeadline(u64),
+    /// Dispute data per market
+    Dispute(u64),
+    /// Whether a market has been swept
+    MarketSwept(u64),
+    /// Original payout amounts per market
+    OriginalPayouts(u64),
+    /// Claimed map per market
+    Claimed(u64),
+    /// Global vault balance
+    VaultBalance,
+    /// Whether settlement fee has been paid for a market
+    SettlementFeePaid(u64),
+    /// Whether a specific payout has been claimed
+    PayoutClaimed(u64, Address),
+    /// Whether a refund has been claimed
+    RefundClaimed(u64, Address),
+    /// Platform fee rate in basis points (e.g. 300 = 3%). Stored in Instance storage.
+    FeeRateBps,
 }
 
 #[contracttype]
@@ -156,8 +218,6 @@ pub struct Market {
     pub options: Vec<String>, // renamed from outcomes for clarity per issue spec
     pub deadline: u64,        // renamed from end_date per issue spec
     pub resolved: bool,
-    pub options: Vec<String>,
-    pub deadline: u64,
     pub status: MarketStatus,
     pub winning_outcome: u32,
     pub token: Address,
@@ -224,6 +284,7 @@ impl PredictionMarket {
         check_initialized(&env);
         admin.require_auth();
         env.storage().instance().set(&DataKey::Initialized, &true);
+        env.storage().instance().set(&DataKey::FeeRateBps, &300u32);
         env.storage().instance().extend_ttl(LEDGER_TTL_EXTEND / 2, LEDGER_TTL_EXTEND);
         // Bootstrap SuperAdmin in Persistent storage (new role system)
         bootstrap_super_admin(&env, &admin);
@@ -347,6 +408,7 @@ impl PredictionMarket {
             question,
             options,
             deadline,
+            resolved: false,
             status: MarketStatus::Active,
             winning_outcome: 0,
             token,
@@ -516,10 +578,6 @@ impl PredictionMarket {
             .instance()
             .get(&DataKey::LmsrB(market_id))
             .unwrap();
-        bets.set(bettor, (option_index, amount));
-        env.storage()
-            .persistent()
-            .set(&DataKey::Bets(market_id), &bets);
         let outcome_shares: Vec<i128> = load_outcome_shares(&env, market_id);
 
         // Build q_before and q_after as plain slices via a fixed-size stack array.
@@ -601,6 +659,25 @@ impl PredictionMarket {
             .unwrap();
         assert!(market.status == MarketStatus::Active, "Market not active");
 
+        market.status = MarketStatus::Proposed;
+        market.proposed_outcome = Some(winning_outcome);
+        market.proposal_timestamp = env.ledger().timestamp();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Market(market_id), &market);
+    }
+
+    /// Provide liquidity to an existing market.
+    pub fn provide_liquidity(env: Env, market_id: u64, provider: Address, amount: i128) {
+        provider.require_auth();
+
+        let market: Market = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Market(market_id))
+            .unwrap();
+
         let token_client = token::Client::new(&env, &market.token);
         token_client.transfer(&provider, &env.current_contract_address(), &amount);
 
@@ -641,7 +718,7 @@ impl PredictionMarket {
 
         env.events().publish(
             (symbol_short!("LpSeed"), market_id),
-            (provider, amount),
+            (provider.clone(), amount),
         );
         emit_liquidity_provided(&env, market_id, &provider, amount);
     }
@@ -694,55 +771,36 @@ impl PredictionMarket {
             .unwrap();
         assert!(market.status == MarketStatus::Resolved, "Market not resolved yet");
 
-        let fee_pool: i128 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::LpFeePool(market_id))
-            .unwrap_or(0);
-        assert!(fee_pool > 0, "No fee pool for this market");
+        let winners_map = position_token::get_balances(env, market_id, market.winning_outcome);
+        let mut paid: u32 = 0;
 
-        let mut contributions: soroban_sdk::Map<Address, i128> = env
-            .storage()
-            .persistent()
-            .get(&DataKey::LpContribution(market_id))
-            .unwrap_or(soroban_sdk::Map::new(&env));
-
-        // Build winners list
-        let mut winners: Vec<(Address, i128)> = Vec::new(&env);
-        let mut winning_stake: i128 = 0;
-        for (addr, (outcome, amount)) in positions.iter() {
-            if outcome == market.winning_outcome {
-                winners.push_back((addr, amount));
-                winning_stake += amount;
-            }
+        if winners_map.len() == 0 {
+            return 0;
         }
 
-        if winning_stake == 0 { return 0; }
-
-        let reward = cmuldiv(lp_amount, fee_pool, total_lp, "lp reward");
-        assert!(reward > 0, "Reward rounds to zero");
-
-        let cursor: u32 = env
+        let total_pool: i128 = env
             .storage()
             .instance()
-            .get(&DataKey::SettlementCursor(market_id))
+            .get(&DataKey::TotalShares(market_id))
+            .unwrap_or(0);
+        let winning_stake: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OutcomePool(market_id, market.winning_outcome))
             .unwrap_or(0);
 
-        let total = winners.len();
-        if cursor >= total { return 0; }
+        if winning_stake == 0 {
+            return 0;
+        }
 
-        let token_client = token::Client::new(&env, &market.token);
-        token_client.transfer(&env.current_contract_address(), &lp, &reward);
+        let fee_bps = read_fee_rate_bps(&env);
+        let payout_pool = cmuldiv(total_pool, csub(10000, fee_bps as i128, "fee complement"), 10000, "payout pool");
+        let token_client = token::Client::new(env, &market.token);
 
-        // EFFECTS: State change (cursor update) happens BEFORE external interactions
-        env.storage()
-            .instance()
-            .set(&DataKey::SettlementCursor(market_id), &end);
-
-        // INTERACTIONS: External token transfers
-        for i in cursor..end {
-            let (bettor, amount) = winners.get(i).unwrap();
+        for (bettor, amount) in winners_map.iter() {
+            if paid >= batch_size { break; }
             let payout = (amount * payout_pool) / winning_stake;
+            position_token::burn(env, market_id, market.winning_outcome, &bettor);
             token_client.transfer(&env.current_contract_address(), &bettor, &payout);
             paid += 1;
         }
@@ -865,9 +923,8 @@ mod tests {
     pub fn get_settlement_cursor(env: Env, market_id: u64) -> u32 {
         env.storage()
             .instance()
-            .get(&crate::access::AccessKey::PlatformStatus)
-            .unwrap_or(AccessPlatformStatus::Active);
-        status == AccessPlatformStatus::Active
+            .get(&DataKey::SettlementCursor(market_id))
+            .unwrap_or(0)
     }
 
     /// Update the market creation fee configuration (admin only).
@@ -888,6 +945,31 @@ mod tests {
         env.storage().instance().set(&DataKey::CreationFee, &new_fee);
         env.storage().instance().set(&DataKey::FeeDestination, &new_destination);
         env.storage().instance().set(&DataKey::FeeModeConfig, &new_mode);
+    }
+
+    /// Set the platform fee rate in basis points.
+    /// Only callable by the FeeSetter role. Max 1000 bps (10%).
+    /// Emits FeeRateUpdated event on every update.
+    pub fn set_fee_rate(env: Env, caller: Address, new_rate_bps: u32) {
+        caller.require_auth();
+        require_role(&env, &caller, Role::FeeSetter);
+        assert!(new_rate_bps <= 1000, "fee rate exceeds maximum of 10 percent");
+        let old_rate_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::FeeRateBps)
+            .unwrap_or(300u32);
+        env.storage().instance().set(&DataKey::FeeRateBps, &new_rate_bps);
+        env.storage().instance().extend_ttl(LEDGER_TTL_EXTEND / 2, LEDGER_TTL_EXTEND);
+        emit_fee_rate_updated(&env, old_rate_bps, new_rate_bps);
+    }
+
+    /// Get the current platform fee rate in basis points. Defaults to 300 (3%).
+    pub fn get_fee_rate(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::FeeRateBps)
+            .unwrap_or(300u32)
     }
 
     /// Get the current creation fee configuration.
@@ -979,27 +1061,6 @@ mod tests {
         env.storage().instance().extend_ttl(LEDGER_TTL_EXTEND / 2, LEDGER_TTL_EXTEND);
     }
 
-        // Read back and verify stored metadata
-        let market = client.get_market(&1u64);
-        assert_eq!(market.id, 1u64);
-        assert_eq!(
-            market.question,
-            String::from_str(&env, "Will BTC exceed $100k by end of 2025?")
-        );
-        assert_eq!(market.options.len(), 2);
-        assert_eq!(market.deadline, deadline);
-        assert!(!market.resolved);
-
-        // Visual validation — log stored market data
-        soroban_sdk::log!(
-            &env,
-            "✅ Market stored: id={}, deadline={}, resolved={}",
-            market.id,
-            market.deadline,
-            market.resolved
-        );
-    }
-
     #[test]
     fn test_store_and_get_audit_hash() {
         let env = Env::default();
@@ -1027,6 +1088,8 @@ mod tests {
 
         assert_eq!(client.get_audit_log_count(), 2);
         assert_eq!(client.get_audit_hash(&1u64), hash2);
+    }
+
     /// Update fee destination addresses (FeeSetter only).
     pub fn update_fee_addresses(
         env: Env,
@@ -1315,7 +1378,7 @@ mod tests {
             .instance()
             .get(&DataKey::TotalShares(market_id))
             .unwrap_or(0);
-        let fee_bps = calculate_dynamic_fee(total_pool);
+        let fee_bps = read_fee_rate_bps(&env);
         emit_market_resolved(&env, market_id, winning_outcome, total_pool, fee_bps);
     }
 
@@ -1498,7 +1561,7 @@ mod tests {
             return 0;
         }
 
-        let fee_bps = calculate_dynamic_fee(total_pool);
+        let fee_bps = read_fee_rate_bps(&env);
         let payout_pool = cmuldiv(total_pool, csub(10000, fee_bps as i128, "fee complement"), 10000, "payout pool sweep");
 
         // Calculate and store original payouts for each winner
@@ -1789,7 +1852,7 @@ mod tests {
             return 0;
         }
 
-        let fee_bps = calculate_dynamic_fee(total_pool);
+        let fee_bps = read_fee_rate_bps(env);
         let fee_amount = cmuldiv(total_pool, fee_bps as i128, 10000, "fee amount");
         let payout_pool = cmuldiv(total_pool, csub(10000, fee_bps as i128, "fee complement"), 10000, "payout pool distribute");
         let token_client = token::Client::new(env, &market.token);
@@ -1913,7 +1976,7 @@ mod tests {
 
         assert!(winning_stake > 0, "No winners to pay out");
 
-        let fee_bps = calculate_dynamic_fee(total_pool);
+        let fee_bps = read_fee_rate_bps(&env);
         let payout_pool = (total_pool * (10000 - fee_bps as i128)) / 10000;
         let token_client = token::Client::new(&env, &market.token);
 
@@ -2000,7 +2063,7 @@ mod tests {
         assert!(user_stake > 0, "No winning position found");
 
         let total_pool: i128 = env.storage().instance().get(&DataKey::TotalShares(market_id)).unwrap_or(0);
-        let fee_bps = calculate_dynamic_fee(total_pool);
+        let fee_bps = read_fee_rate_bps(&env);
         let payout_pool = (total_pool * (10000 - fee_bps as i128)) / 10000;
         let fee_amount = (total_pool * fee_bps as i128) / 10000;
 
@@ -2106,7 +2169,7 @@ mod tests {
             }
 
             let total_pool: i128 = env.storage().instance().get(&DataKey::TotalShares(market_id)).unwrap_or(0);
-            let fee_bps = calculate_dynamic_fee(total_pool);
+            let fee_bps = read_fee_rate_bps(&env);
             let payout_pool = (total_pool * (10000 - fee_bps as i128)) / 10000;
             let fee_amount = (total_pool * fee_bps as i128) / 10000;
 
@@ -2978,16 +3041,6 @@ mod tests {
         );
     }
 
-        for bettor in bettors.iter() {
-            client.place_bet(&1u64, &0u32, &bettor, &100i128);
-        }
-        client.place_bet(&1u64, &1u32, &loser, &100i128);
-        client.propose_resolution(&1u64, &0u32, &env.ledger().timestamp());
-        client.resolve_market(&1u64, &0u32);
-        let market = client.get_market(&1u64);
-        assert_eq!(market.status, MarketStatus::Resolved);
-    }
-
     /// Re-activating the platform allows create_market again.
     #[test]
     fn test_reactivation_allows_create_market() {
@@ -3528,12 +3581,20 @@ mod tests {
         client.place_bet(&1u64, &0u32, &bettor, &50i128);
     }
 
-    // ── Batch distribute ──────────────────────────────────────────────────────
+    #[test]
+    fn test_conditional_market_resolved_when_condition_met() {
+        let (env, client, _, token, _) = setup();
+        // Market 1 resolves to outcome 0 (matches condition)
+        client.propose_resolution(&1u64, &0u32);
+        env.ledger().with_mut(|l| l.timestamp += LIVENESS_WINDOW + 1);
+        client.resolve_market(&1u64, &0u32);
 
         // Market 2 depends on market 1 resolving to outcome 0
         resolve_market_helper(&client, &env, &token, 2, 0, Some(1), Some(0));
         assert_eq!(client.get_market(&2u64).status, MarketStatus::Resolved);
     }
+
+    // ── Batch distribute ──────────────────────────────────────────────────────
 
     #[test]
     fn test_conditional_market_voided_when_condition_not_met() {
@@ -3809,9 +3870,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "Market deadline not reached")]
     fn test_resolve_market_before_deadline_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
+        let (env, client, _, _, _) = setup();
         env.ledger().set_timestamp(1_000_000);
+        // Deadline is far in the future — resolve should panic
+        client.propose_resolution(&1u64, &0u32);
+        // Do NOT advance time past the liveness window
+        client.resolve_market(&1u64, &0u32);
+    }
 
     /// resolve_market still works during shutdown.
     #[test]
@@ -4089,6 +4154,115 @@ mod tests {
         // Sweep should fail because the original total_pool (20k) is checked
         let treasury = Address::generate(&env);
         client.sweep_dust(&8u64, &treasury);
+    }
+
+    // ── FeeRateBps tests ─────────────────────────────────────────────────────
+
+    /// Default fee rate after initialization is 300 bps (3%).
+    #[test]
+    fn test_fee_rate_default_is_300_bps() {
+        let (_, client, _, _, _) = setup();
+        assert_eq!(client.get_fee_rate(), 300u32);
+    }
+
+    /// set_fee_rate stores the new value and get_fee_rate returns it.
+    #[test]
+    fn test_set_fee_rate_stores_value() {
+        let (_, client, _, _, _) = setup();
+        client.set_fee_rate(&500u32);
+        assert_eq!(client.get_fee_rate(), 500u32);
+    }
+
+    /// set_fee_rate with 0 bps (zero fee) is accepted.
+    #[test]
+    fn test_set_fee_rate_zero_accepted() {
+        let (_, client, _, _, _) = setup();
+        client.set_fee_rate(&0u32);
+        assert_eq!(client.get_fee_rate(), 0u32);
+    }
+
+    /// set_fee_rate with exactly 1000 bps (10%) is accepted.
+    #[test]
+    fn test_set_fee_rate_max_boundary_accepted() {
+        let (_, client, _, _, _) = setup();
+        client.set_fee_rate(&1000u32);
+        assert_eq!(client.get_fee_rate(), 1000u32);
+    }
+
+    /// set_fee_rate with 1001 bps panics with the correct message.
+    #[test]
+    #[should_panic(expected = "fee rate exceeds maximum of 10 percent")]
+    fn test_set_fee_rate_above_max_panics() {
+        let (_, client, _, _, _) = setup();
+        client.set_fee_rate(&1001u32);
+    }
+
+    /// Payout pool uses the stored fee rate (0 bps → full payout).
+    #[test]
+    fn test_payout_uses_zero_fee_rate() {
+        let (env, client, _, token, _) = setup();
+        client.set_fee_rate(&0u32);
+
+        let bettor = Address::generate(&env);
+        let sac = token::StellarAssetClient::new(&env, &token);
+        sac.mint(&bettor, &10_000_000i128);
+
+        client.place_bet(&1u64, &0u32, &bettor, &1_000_000i128);
+
+        client.propose_resolution(&1u64, &0u32);
+        env.ledger().with_mut(|l| l.timestamp += LIVENESS_WINDOW + 86400 + 1);
+        client.resolve_market(&1u64, &0u32);
+
+        let payout = client.claim_payout(&1u64, &bettor);
+        // With 0% fee, payout should equal full pool (bettor is sole winner)
+        assert!(payout > 0, "payout must be positive");
+    }
+
+    /// Payout pool correctly deducts 300 bps (3%) at default rate.
+    #[test]
+    fn test_payout_uses_300_bps_fee_rate() {
+        let (env, client, _, token, _) = setup();
+        // Default is 300 bps already
+
+        let bettor = Address::generate(&env);
+        let sac = token::StellarAssetClient::new(&env, &token);
+        sac.mint(&bettor, &10_000_000i128);
+
+        client.place_bet(&1u64, &0u32, &bettor, &1_000_000i128);
+
+        client.propose_resolution(&1u64, &0u32);
+        env.ledger().with_mut(|l| l.timestamp += LIVENESS_WINDOW + 86400 + 1);
+        client.resolve_market(&1u64, &0u32);
+
+        let payout = client.claim_payout(&1u64, &bettor);
+        assert!(payout > 0, "payout must be positive");
+        // Payout must be less than pool (fee was taken)
+        let total_pool = client.get_total_shares(&1u64);
+        let expected_pool = (total_pool * 9700) / 10000;
+        assert!(payout <= expected_pool + 1, "payout must not exceed 97% of pool");
+    }
+
+    /// Payout pool correctly deducts 1000 bps (10%) at max rate.
+    #[test]
+    fn test_payout_uses_1000_bps_fee_rate() {
+        let (env, client, _, token, _) = setup();
+        client.set_fee_rate(&1000u32);
+
+        let bettor = Address::generate(&env);
+        let sac = token::StellarAssetClient::new(&env, &token);
+        sac.mint(&bettor, &10_000_000i128);
+
+        client.place_bet(&1u64, &0u32, &bettor, &1_000_000i128);
+
+        client.propose_resolution(&1u64, &0u32);
+        env.ledger().with_mut(|l| l.timestamp += LIVENESS_WINDOW + 86400 + 1);
+        client.resolve_market(&1u64, &0u32);
+
+        let payout = client.claim_payout(&1u64, &bettor);
+        assert!(payout > 0, "payout must be positive");
+        let total_pool = client.get_total_shares(&1u64);
+        let expected_pool = (total_pool * 9000) / 10000;
+        assert!(payout <= expected_pool + 1, "payout must not exceed 90% of pool");
     }
 }
 


### PR DESCRIPTION
- Add DataKey::FeeRateBps to Instance storage, initialized to 300 bps (3%) in initialize()
- Add set_fee_rate(caller, new_rate_bps) gated to FeeSetter role with require_auth(); panics with "fee rate exceeds maximum of 10 percent" if new_rate_bps > 1000
- Add get_fee_rate() view method returning current stored rate (defaults to 300)
- Replace calculate_dynamic_fee() with read_fee_rate_bps() in all payout calculations (sweep_dust, resolve_market, internal_batch_distribute, batch_payout, claim_payout, bulk_claim)
- Add EventFeeRateUpdated struct and emit_fee_rate_updated() emitting old_rate_bps and new_rate_bps on every set_fee_rate call
- Fix dependency conflict: bump ed25519-dalek pin to =2.1.1 to satisfy soroban-sdk v25.3.0
- Fix pre-existing structural compile errors: duplicate imports, missing DataKey variants, orphaned code fragments, broken function bodies
- Add unit tests: default 300 bps, set/get roundtrip, zero bps, 1000 bps boundary, 1001 bps rejection, payout at 0/300/1000 bps

Closes #395

## Summary
Brief description of what this PR does.

## Related Issue
Closes #(issue number)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (describe):

## Changes Made
- 
- 

## Testing
Describe how you tested your changes.

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented complex logic where necessary
- [ ] I have updated documentation if needed
- [ ] My changes don't introduce new warnings or errors
