### PR TITLE
feat: implement PWA manifest and service worker for offline support

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
         "!**/hooks/__tests__/useMarketSearch.test.ts",
         "!**/hooks/__tests__/useBatchTransaction.test.ts",
         "!**/hooks/__tests__/useMarkets.test.ts",
+        "!**/hooks/__tests__/useOnlineStatus.test.ts",
       ],
       globals: {
         "ts-jest": { tsconfig: { esModuleInterop: true } },
@@ -37,6 +38,7 @@ module.exports = {
         "**/hooks/__tests__/useMarketSearch.test.ts",
         "**/hooks/__tests__/useBatchTransaction.test.ts",
         "**/hooks/__tests__/useMarkets.test.ts",
+        "**/hooks/__tests__/useOnlineStatus.test.ts",
       ],
       globals: {
         "ts-jest": {
@@ -52,8 +54,10 @@ module.exports = {
         "src/hooks/useMarkets.ts",
         "src/hooks/useMarket.ts",
         "src/hooks/usePlaceBet.ts",
+        "src/hooks/useOnlineStatus.ts",
         "src/components/VirtualizedOrderBook.tsx",
         "src/components/LiveActivityFeed.tsx",
+        "src/components/OfflineBanner.tsx",
       ],
       coverageThreshold: {
         global: { lines: 90, functions: 90, branches: 90 },

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,9 +1,60 @@
 /** @type {import('next').NextConfig} */
 
 // Bundle analyzer — run with: ANALYZE=true npm run build:webpack
-// Note: @next/bundle-analyzer requires webpack mode (--webpack flag)
 const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
+});
+
+const withPWA = require("next-pwa")({
+  dest: "public",
+  disable: process.env.NODE_ENV === "development",
+  register: true,
+  skipWaiting: true,
+  // Network-first for API calls (5s timeout → fallback to cache)
+  runtimeCaching: [
+    {
+      urlPattern: ({ url }) =>
+        url.origin === (process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000"),
+      handler: "NetworkFirst",
+      options: {
+        cacheName: "api-cache",
+        networkTimeoutSeconds: 5,
+        expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 },
+        cacheableResponse: { statuses: [0, 200] },
+      },
+    },
+    {
+      // Cache last-fetched markets list
+      urlPattern: /\/api\/markets/,
+      handler: "NetworkFirst",
+      options: {
+        cacheName: "markets-cache",
+        networkTimeoutSeconds: 5,
+        expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 },
+        cacheableResponse: { statuses: [0, 200] },
+      },
+    },
+    {
+      // Cache-first for static assets
+      urlPattern: /\.(?:js|css|woff2?|png|jpg|jpeg|svg|ico|webp)$/i,
+      handler: "CacheFirst",
+      options: {
+        cacheName: "static-assets",
+        expiration: { maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 30 },
+        cacheableResponse: { statuses: [0, 200] },
+      },
+    },
+    {
+      // Cache Next.js pages (network-first)
+      urlPattern: /^\/_next\//,
+      handler: "CacheFirst",
+      options: {
+        cacheName: "next-static",
+        expiration: { maxEntries: 200, maxAgeSeconds: 60 * 60 * 24 * 30 },
+        cacheableResponse: { statuses: [0, 200] },
+      },
+    },
+  ],
 });
 
 const nextConfig = {
@@ -13,41 +64,32 @@ const nextConfig = {
   },
 
   // Turbopack config (Next.js 16 default bundler)
-  // Vendor chunk splitting is handled automatically by Turbopack.
-  // For manual analysis, use: npm run build:webpack
   turbopack: {},
 
   // Webpack config — used only when building with --webpack flag
-  // (e.g. npm run build:webpack or ANALYZE=true npm run build:webpack)
   webpack(config, { isServer }) {
     if (!isServer) {
-      // Split heavy third-party libs into separate cached chunks so they are
-      // not re-downloaded when app code changes.
       config.optimization.splitChunks = {
         ...config.optimization.splitChunks,
         cacheGroups: {
-          // recharts + d3 deps into one chunk — only loaded on chart pages
           recharts: {
             test: /[\\/]node_modules[\\/](recharts|d3-.*|victory-.*)[\\/]/,
             name: "vendor-recharts",
             chunks: "all",
             priority: 30,
           },
-          // Stellar SDK — large, rarely changes
           stellar: {
             test: /[\\/]node_modules[\\/](@stellar|stellar-base)[\\/]/,
             name: "vendor-stellar",
             chunks: "all",
             priority: 20,
           },
-          // Firebase — large, rarely changes
           firebase: {
             test: /[\\/]node_modules[\\/](firebase|@firebase)[\\/]/,
             name: "vendor-firebase",
             chunks: "all",
             priority: 20,
           },
-          // Everything else in node_modules
           vendors: {
             test: /[\\/]node_modules[\\/]/,
             name: "vendors",
@@ -61,4 +103,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withBundleAnalyzer(nextConfig);
+module.exports = withBundleAnalyzer(withPWA(nextConfig));

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.11.2",
+    "next-pwa": "^5.6.0",
     "@sentry/nextjs": "^10.46.0",
     "@stellar/freighter-api": "^1.7.1",
     "@stellar/stellar-sdk": "^11.0.0",

--- a/frontend/public/icons/README.md
+++ b/frontend/public/icons/README.md
@@ -1,0 +1,14 @@
+# PWA Icons
+
+Place the following icon files here:
+
+- `icon-192x192.png` — 192×192px app icon (used on Android home screen)
+- `icon-512x512.png` — 512×512px app icon (used for splash screen / install prompt)
+
+Both should use the Stella Polymarket brand mark on a `#2563eb` (blue-600) background.
+Use `purpose: "any maskable"` safe zone (80% of canvas) for the logo.
+
+You can generate them from an SVG using:
+```
+npx pwa-asset-generator logo.svg public/icons --manifest public/manifest.json
+```

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "Stella Polymarket",
+  "short_name": "Stella",
+  "description": "Decentralized prediction markets on Stellar",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#030712",
+  "theme_color": "#2563eb",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["finance", "utilities"],
+  "screenshots": []
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -7,10 +7,18 @@ import ReduxProvider from "../components/ReduxProvider";
 import SkipLink from "../components/SkipLink";
 import ReactQueryProvider from "../components/ReactQueryProvider";
 import ThemeScript from "../components/ThemeScript";
+import OfflineBanner from "../components/OfflineBanner";
 
 export const metadata: Metadata = {
   title: "Stella Polymarket",
   description: "Decentralized prediction markets on Stellar",
+  manifest: "/manifest.json",
+  themeColor: "#2563eb",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "Stella",
+  },
 };
 
 import { ToastProvider } from "../components/ToastProvider";
@@ -24,6 +32,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body>
         <SkipLink />
+        <OfflineBanner />
         <ReduxProvider>
           <ReactQueryProvider>
             {/* WalletProvider lifts wallet state globally so BettingSlip can submit */}

--- a/frontend/src/components/BettingSlip.tsx
+++ b/frontend/src/components/BettingSlip.tsx
@@ -16,6 +16,7 @@
  */
 import { useBettingSlip, MAX_BETS } from "../context/BettingSlipContext";
 import { useBatchTransaction } from "../hooks/useBatchTransaction";
+import { useOnlineStatus } from "../hooks/useOnlineStatus";
 
 interface Props {
   walletAddress: string | null;
@@ -28,6 +29,7 @@ export default function BettingSlip({ walletAddress, onBatchPlaced }: Props) {
     clearBets();
     onBatchPlaced?.();
   });
+  const isOnline = useOnlineStatus();
 
   async function handleSubmit() {
     if (!walletAddress || !bets.length) return;
@@ -141,14 +143,27 @@ export default function BettingSlip({ walletAddress, onBatchPlaced }: Props) {
             )}
 
             {walletAddress ? (
-              <button
-                data-testid="submit-batch"
-                onClick={handleSubmit}
-                disabled={submitting || bets.length === 0}
-                className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed px-4 py-3 rounded-xl text-sm font-bold transition-colors"
-              >
-                {submitting ? "Submitting..." : `Place ${bets.length} Bet${bets.length > 1 ? "s" : ""}`}
-              </button>
+              <div className="relative group">
+                <button
+                  data-testid="submit-batch"
+                  onClick={handleSubmit}
+                  disabled={submitting || bets.length === 0 || !isOnline}
+                  aria-disabled={!isOnline}
+                  className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed px-4 py-3 rounded-xl text-sm font-bold transition-colors"
+                >
+                  {submitting ? "Submitting..." : `Place ${bets.length} Bet${bets.length > 1 ? "s" : ""}`}
+                </button>
+                {!isOnline && (
+                  <div
+                    role="tooltip"
+                    data-testid="offline-bet-tooltip"
+                    className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 rounded-lg text-xs font-medium whitespace-nowrap pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity"
+                    style={{ backgroundColor: "var(--bg-elevated)", color: "var(--status-warning)" }}
+                  >
+                    You&apos;re offline — bet submission unavailable
+                  </div>
+                )}
+              </div>
             ) : (
               <p className="text-gray-400 text-xs text-center py-2">
                 Connect your wallet to submit bets

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { useOnlineStatus } from "../hooks/useOnlineStatus";
+
+/**
+ * Sticky banner shown when the user loses network connectivity.
+ * Disappears automatically when connectivity is restored.
+ */
+export default function OfflineBanner() {
+  const isOnline = useOnlineStatus();
+
+  if (isOnline) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="offline-banner"
+      className="fixed top-0 left-0 right-0 z-[100] flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium"
+      style={{ backgroundColor: "var(--status-warning-bg)", color: "var(--status-warning)" }}
+    >
+      {/* Wifi-off icon */}
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="w-4 h-4 shrink-0"
+      >
+        <line x1="1" y1="1" x2="23" y2="23" />
+        <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55" />
+        <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39" />
+        <path d="M10.71 5.05A16 16 0 0 1 22.56 9" />
+        <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88" />
+        <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
+        <line x1="12" y1="20" x2="12.01" y2="20" />
+      </svg>
+      You&apos;re offline — showing cached data. Bet submission is unavailable.
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/BettingSlip.test.tsx
+++ b/frontend/src/components/__tests__/BettingSlip.test.tsx
@@ -131,3 +131,56 @@ describe("BettingSlip", () => {
     });
   });
 });
+
+// ── Offline behaviour ────────────────────────────────────────────────────────
+
+const OFFLINE_BETS = [
+  { marketId: 1, title: "Will BTC hit 100k?", outcome: "Yes", amount: 50 },
+];
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+describe("BettingSlip — offline", () => {
+  afterEach(() => setOnline(true));
+
+  it("disables submit button when offline", async () => {
+    setOnline(false);
+    renderSlip("GTEST", OFFLINE_BETS);
+    await waitFor(() => screen.getByTestId("submit-batch"));
+    expect(screen.getByTestId("submit-batch")).toBeDisabled();
+  });
+
+  it("shows offline tooltip on submit button when offline", async () => {
+    setOnline(false);
+    renderSlip("GTEST", OFFLINE_BETS);
+    await waitFor(() => screen.getByTestId("offline-bet-tooltip"));
+    expect(screen.getByTestId("offline-bet-tooltip")).toBeInTheDocument();
+    expect(screen.getByTestId("offline-bet-tooltip")).toHaveTextContent(/offline/i);
+  });
+
+  it("enables submit button when back online", async () => {
+    setOnline(false);
+    renderSlip("GTEST", OFFLINE_BETS);
+    await waitFor(() => screen.getByTestId("submit-batch"));
+    expect(screen.getByTestId("submit-batch")).toBeDisabled();
+
+    // Simulate coming back online
+    setOnline(true);
+    fireEvent(window, new Event("online"));
+    await waitFor(() => {
+      expect(screen.getByTestId("submit-batch")).not.toBeDisabled();
+    });
+  });
+
+  it("does not show offline tooltip when online", async () => {
+    setOnline(true);
+    renderSlip("GTEST", OFFLINE_BETS);
+    await waitFor(() => screen.getByTestId("submit-batch"));
+    expect(screen.queryByTestId("offline-bet-tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/OfflineBanner.test.tsx
+++ b/frontend/src/components/__tests__/OfflineBanner.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import OfflineBanner from "../OfflineBanner";
+
+const fireNetworkEvent = (type: "online" | "offline") => {
+  act(() => {
+    window.dispatchEvent(new Event(type));
+  });
+};
+
+describe("OfflineBanner", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => true,
+    });
+  });
+
+  it("renders nothing when online", () => {
+    render(<OfflineBanner />);
+    expect(screen.queryByTestId("offline-banner")).not.toBeInTheDocument();
+  });
+
+  it("renders banner when offline", () => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    render(<OfflineBanner />);
+    expect(screen.getByTestId("offline-banner")).toBeInTheDocument();
+  });
+
+  it("shows offline message text", () => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    render(<OfflineBanner />);
+    expect(screen.getByText(/you're offline/i)).toBeInTheDocument();
+    expect(screen.getByText(/cached data/i)).toBeInTheDocument();
+  });
+
+  it("appears when offline event fires", () => {
+    render(<OfflineBanner />);
+    expect(screen.queryByTestId("offline-banner")).not.toBeInTheDocument();
+    fireNetworkEvent("offline");
+    expect(screen.getByTestId("offline-banner")).toBeInTheDocument();
+  });
+
+  it("disappears when online event fires after going offline", () => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    render(<OfflineBanner />);
+    expect(screen.getByTestId("offline-banner")).toBeInTheDocument();
+    fireNetworkEvent("online");
+    expect(screen.queryByTestId("offline-banner")).not.toBeInTheDocument();
+  });
+
+  it("has role=status and aria-live=polite for accessibility", () => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    render(<OfflineBanner />);
+    const banner = screen.getByTestId("offline-banner");
+    expect(banner).toHaveAttribute("role", "status");
+    expect(banner).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("toggles correctly through multiple transitions", () => {
+    render(<OfflineBanner />);
+    fireNetworkEvent("offline");
+    expect(screen.getByTestId("offline-banner")).toBeInTheDocument();
+    fireNetworkEvent("online");
+    expect(screen.queryByTestId("offline-banner")).not.toBeInTheDocument();
+    fireNetworkEvent("offline");
+    expect(screen.getByTestId("offline-banner")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/__tests__/useOnlineStatus.test.ts
+++ b/frontend/src/hooks/__tests__/useOnlineStatus.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, act } from "@testing-library/react";
+import { useOnlineStatus } from "../useOnlineStatus";
+
+describe("useOnlineStatus", () => {
+  const fireEvent = (type: "online" | "offline") => {
+    act(() => {
+      window.dispatchEvent(new Event(type));
+    });
+  };
+
+  beforeEach(() => {
+    // Default: online
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => true,
+    });
+  });
+
+  it("returns true when navigator.onLine is true", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when navigator.onLine is false", () => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+  });
+
+  it("updates to false on offline event", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+    fireEvent("offline");
+    expect(result.current).toBe(false);
+  });
+
+  it("updates to true on online event after going offline", () => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+    fireEvent("online");
+    expect(result.current).toBe(true);
+  });
+
+  it("removes event listeners on unmount", () => {
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useOnlineStatus());
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith("online", expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith("offline", expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it("handles multiple online/offline transitions", () => {
+    const { result } = renderHook(() => useOnlineStatus());
+    fireEvent("offline");
+    expect(result.current).toBe(false);
+    fireEvent("online");
+    expect(result.current).toBe(true);
+    fireEvent("offline");
+    expect(result.current).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useOnlineStatus.ts
+++ b/frontend/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,27 @@
+"use client";
+import { useState, useEffect } from "react";
+
+/**
+ * Tracks navigator.onLine and listens for online/offline events.
+ * Returns true when the browser has network connectivity.
+ */
+export function useOnlineStatus(): boolean {
+  const [isOnline, setIsOnline] = useState<boolean>(
+    typeof navigator !== "undefined" ? navigator.onLine : true
+  );
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}


### PR DESCRIPTION
- Add next-pwa with network-first (5s timeout) for API, cache-first for static assets
- Add public/manifest.json with standalone display and brand colors
- Add useOnlineStatus hook tracking navigator.onLine events
- Add OfflineBanner component with aria-live for accessibility
- Disable bet submission with tooltip when offline in BettingSlip
- Wire manifest/themeColor metadata and OfflineBanner into root layout
- Add tests for useOnlineStatus, OfflineBanner, and BettingSlip offline behaviour
- Update jest.config.js to cover new files with >90% threshold

Closes #459

## Summary
Brief description of what this PR does.

## Related Issue
Closes #(issue number)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (describe):

## Changes Made
- closes #470 
- 

## Testing
Describe how you tested your changes.

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented complex logic where necessary
- [ ] I have updated documentation if needed
- [ ] My changes don't introduce new warnings or errors
