### PR TITLE
Platform safety and order book hardening

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -20,8 +20,6 @@ if (!admin.apps.length) {
 
 const appCheckMiddleware = require("./middleware/appCheck");
 
-const app = express();
-
 // ── CORS ────────────────────────────────────────────────────────────────────
 // Restrict allowed origins to the official frontend domain.
 // Set ALLOWED_ORIGINS as a comma-separated list in production env vars.
@@ -30,120 +28,171 @@ const allowedOrigins = process.env.ALLOWED_ORIGINS
   ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim())
   : ["http://localhost:3000"];
 
-app.use(
-  cors({
-    origin(origin, callback) {
-      // Allow server-to-server requests (no Origin header) and listed origins
-      if (!origin || allowedOrigins.includes(origin)) {
-        callback(null, true);
-      } else {
-        callback(new Error(`CORS: origin '${origin}' not allowed`));
-      }
-    },
-    credentials: true,
-  })
-);
-// ────────────────────────────────────────────────────────────────────────────
+function applyCommonMiddleware(app) {
+  app.use(
+    cors({
+      origin(origin, callback) {
+        // Allow server-to-server requests (no Origin header) and listed origins
+        if (!origin || allowedOrigins.includes(origin)) {
+          callback(null, true);
+        } else {
+          callback(new Error(`CORS: origin '${origin}' not allowed`));
+        }
+      },
+      credentials: true,
+    })
+  );
 
-app.use(express.json());
+  // Explicit 10kb body limits reduce memory exposure from oversized payload attacks.
+  app.use(express.json({ limit: "10kb" }));
+  app.use(express.urlencoded({ extended: true, limit: "10kb" }));
 
-// Request logging middleware
-app.use((req, res, _next) => {
-  const start = Date.now();
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    logger.info(
+  // Request logging middleware
+  app.use((req, res, _next) => {
+    const start = Date.now();
+    res.on("finish", () => {
+      const duration = Date.now() - start;
+      logger.info(
+        {
+          method: req.method,
+          path: req.path,
+          status: res.statusCode,
+          duration_ms: duration,
+          ip: req.ip,
+        },
+        "HTTP Request"
+      );
+    });
+    _next();
+  });
+}
+
+function applyRoutes(app) {
+  // Health and readiness probes — NOT behind App Check so orchestrators can probe freely
+  const healthRouter = require("./routes/health");
+  app.use(healthRouter);
+  app.use("/api/health", require("./routes/health/protocolHealth"));
+
+  // Prometheus metrics — NOT behind App Check so Prometheus can scrape freely
+  app.use("/metrics", require("./routes/metrics"));
+
+  // ── App Check enforcement ─────────────────────────────────────────────────
+  // All /api/* routes are protected. Any request without a valid
+  // X-Firebase-AppCheck header receives HTTP 403 before reaching the handler.
+  app.use("/api", appCheckMiddleware);
+  // ──────────────────────────────────────────────────────────────────────────
+
+  app.use("/api/markets", require("./routes/markets"));
+  app.use("/api/bets", require("./routes/bets"));
+  app.use("/api/notifications", require("./routes/notifications"));
+  app.use("/api/reserves", require("./routes/reserves"));
+  app.use("/api/audit-logs", require("./routes/audit"));
+
+  const shortUrlRoutes = require("./routes/shorturl");
+  app.use("/api/short-url", shortUrlRoutes);
+  app.get("/s/:code", shortUrlRoutes.redirectHandler);
+  app.use("/api/status", require("./routes/status"));
+  app.use("/api/images", require("./routes/images"));
+  app.use("/api/v1/oracles", require("./routes/oracles"));
+  app.use("/api/tvl", require("./routes/tvl"));
+  app.use("/api/governance", require("./routes/governance"));
+  app.use("/api/admin", require("./routes/admin"));
+  app.use("/api/indexer", require("./routes/indexer"));
+  app.use("/api/archive", require("./routes/archive"));
+  app.use("/api/portfolio", require("./routes/portfolio"));
+
+  // GraphQL endpoint (graphql-yoga as Express middleware)
+  const { createYoga } = require("graphql-yoga");
+  const schema = require("./graphql/schema");
+  const yoga = createYoga({ schema, graphqlEndpoint: "/graphql", logging: false });
+  app.use("/graphql", yoga);
+
+  return { schema };
+}
+
+function applyErrorHandlers(app) {
+  app.use((err, req, res, next) => {
+    if (err?.type === "entity.too.large" || err?.status === 413) {
+      logger.warn(
+        { method: req.method, path: req.path },
+        "Request body rejected: payload too large"
+      );
+      return res.status(413).json({ error: "Request body exceeds the 10kb limit." });
+    }
+    return next(err);
+  });
+
+  app.use((err, req, res, _next) => {
+    logger.error(
       {
+        err,
         method: req.method,
         path: req.path,
-        status: res.statusCode,
-        duration_ms: duration,
-        ip: req.ip,
+        body: req.body,
       },
-      "HTTP Request"
+      "Unhandled error"
+    );
+    res.status(500).json({ error: "Internal server error" });
+  });
+}
+
+function createApp(options = {}) {
+  const { includeRoutes = true } = options;
+  const app = express();
+  applyCommonMiddleware(app);
+
+  let schema = null;
+  if (includeRoutes) {
+    ({ schema } = applyRoutes(app));
+  }
+
+  applyErrorHandlers(app);
+  return { app, schema };
+}
+
+function startBackgroundServices() {
+  // Start TVL background poller (updates Prometheus gauges every 30 s)
+  require("./services/tvlService").startPoller();
+  // Initialise bot registry — subscribes all strategies to the event bus
+  require("./bots/registry");
+  // Start automated market resolver cron (every 5 minutes)
+  require("./workers/resolver").start();
+  // Start nightly market archival cron (02:00 UTC)
+  require("./workers/archive-worker").start();
+  // Subscribe prediction market contract to Mercury Indexer
+  require("./indexer/mercury").subscribe();
+  // Initialize self-healing gap detection and recovery
+  require("./indexer/gap-detector").initializeSelfHealing();
+}
+
+function startServer() {
+  const { app, schema } = createApp();
+  startBackgroundServices();
+
+  const PORT = process.env.PORT || 4000;
+  const http = require("http");
+  const httpServer = http.createServer(app);
+
+  // Attach graphql-ws WebSocket server (subscriptions at /graphql)
+  require("./graphql/wsServer").attach(httpServer, schema);
+
+  httpServer.listen(PORT, () => {
+    logger.info(
+      { port: PORT, environment: process.env.NODE_ENV || "development" },
+      "Server started"
     );
   });
-  _next();
-});
 
-// Health and readiness probes — NOT behind App Check so orchestrators can probe freely
-const healthRouter = require("./routes/health");
-app.use(healthRouter);
-app.use("/api/health", require("./routes/health/protocolHealth"));
+  return { app, httpServer };
+}
 
-// Prometheus metrics — NOT behind App Check so Prometheus can scrape freely
-app.use("/metrics", require("./routes/metrics"));
-
-// ── App Check enforcement ───────────────────────────────────────────────────
-// All /api/* routes are protected. Any request without a valid
-// X-Firebase-AppCheck header receives HTTP 403 before reaching the handler.
-app.use("/api", appCheckMiddleware);
-// ───────────────────────────────────────────────────────────────────────────
-
-// Routes
-app.use("/api/markets", require("./routes/markets"));
-app.use("/api/bets", require("./routes/bets"));
-app.use("/api/notifications", require("./routes/notifications"));
-app.use("/api/reserves", require("./routes/reserves"));
-app.use("/api/audit-logs", require("./routes/audit"));
-
-const shortUrlRoutes = require("./routes/shorturl");
-app.use("/api/short-url", shortUrlRoutes);
-app.get("/s/:code", shortUrlRoutes.redirectHandler);
-app.use("/api/status", require("./routes/status"));
-app.use("/api/images", require("./routes/images"));
-app.use("/api/v1/oracles", require("./routes/oracles"));
-app.use("/api/tvl", require("./routes/tvl"));
-
-// Start TVL background poller (updates Prometheus gauges every 30 s)
-require("./services/tvlService").startPoller();
-app.use("/api/governance", require("./routes/governance"));
-app.use("/api/admin", require("./routes/admin"));
-app.use("/api/indexer", require("./routes/indexer"));
-app.use("/api/archive", require("./routes/archive"));
-
-// GraphQL endpoint (graphql-yoga as Express middleware)
-const { createYoga } = require("graphql-yoga");
-const schema = require("./graphql/schema");
-const yoga = createYoga({ schema, graphqlEndpoint: "/graphql", logging: false });
-app.use("/graphql", yoga);
-
-// Initialise bot registry — subscribes all strategies to the event bus
-require("./bots/registry");
-
-// Start automated market resolver cron (every 5 minutes)
-require("./workers/resolver").start();
-
-// Start nightly market archival cron (02:00 UTC)
-require("./workers/archive-worker").start();
-
-// Subscribe prediction market contract to Mercury Indexer
-require("./indexer/mercury").subscribe();
-
-// Initialize self-healing gap detection and recovery
-require("./indexer/gap-detector").initializeSelfHealing();
-
-// Global error handler
-app.use((err, req, res, _next) => {
-  logger.error(
-    {
-      err,
-      method: req.method,
-      path: req.path,
-      body: req.body,
-    },
-    "Unhandled error"
-  );
-  res.status(500).json({ error: "Internal server error" });
-});
-
-const PORT = process.env.PORT || 4000;
-const http = require("http");
-const httpServer = http.createServer(app);
-
-// Attach graphql-ws WebSocket server (subscriptions at /graphql)
-require("./graphql/wsServer").attach(httpServer, schema);
-
-httpServer.listen(PORT, () => {
-  logger.info({ port: PORT, environment: process.env.NODE_ENV || "development" }, "Server started");
-});
+if (require.main === module) {
+  startServer();
+}
+module.exports = {
+  applyCommonMiddleware,
+  applyErrorHandlers,
+  applyRoutes,
+  createApp,
+  startServer,
+};

--- a/backend/src/routes/markets.js
+++ b/backend/src/routes/markets.js
@@ -3,14 +3,14 @@ const router = express.Router();
 const db = require("../db");
 const { triggerNotification } = require("../utils/notifications");
 const logger = require("../utils/logger");
-const { 
-  validateMarketCreation, 
-  rateLimitMarketCreation 
+const {
+  validateMarketCreation,
+  rateLimitMarketCreation,
 } = require("../middleware/marketValidation");
 const redis = require("../utils/redis");
 const { calculateOdds } = require("../utils/math");
 const eventBus = require("../bots/eventBus");
-const { getOrSet, invalidateAll, invalidateMarket, detailKey, TTL } = require("../utils/cache");
+const { getOrSet, invalidateAll, detailKey, TTL } = require("../utils/cache");
 
 // GET /api/markets — list all markets with pagination
 router.get("/", async (req, res) => {
@@ -18,35 +18,54 @@ router.get("/", async (req, res) => {
     // Parse and validate pagination parameters
     const limitParam = req.query.limit;
     const offsetParam = req.query.offset;
-    
+    const integerPattern = /^\d+$/;
+
     let limit = 20; // default
     let offset = 0; // default
-    
+
     // Validate limit
     if (limitParam !== undefined) {
-      const parsedLimit = Number(limitParam);
-      if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > 100) {
-        return res.status(400).json({ 
+      if (!integerPattern.test(String(limitParam))) {
+        return res.status(400).json({
           error: {
-            code: 'INVALID_LIMIT',
-            message: 'limit must be an integer between 1 and 100',
-            details: { provided: limitParam }
-          }
+            code: "INVALID_LIMIT",
+            message: "limit must be an integer between 1 and 100",
+            details: { provided: limitParam },
+          },
+        });
+      }
+      const parsedLimit = parseInt(limitParam, 10);
+      if (isNaN(parsedLimit) || parsedLimit < 1 || parsedLimit > 100) {
+        return res.status(400).json({
+          error: {
+            code: "INVALID_LIMIT",
+            message: "limit must be an integer between 1 and 100",
+            details: { provided: limitParam },
+          },
         });
       }
       limit = parsedLimit;
     }
-    
+
     // Validate offset
     if (offsetParam !== undefined) {
-      const parsedOffset = Number(offsetParam);
-      if (!Number.isInteger(parsedOffset) || parsedOffset < 0) {
-        return res.status(400).json({ 
+      if (!integerPattern.test(String(offsetParam))) {
+        return res.status(400).json({
           error: {
-            code: 'INVALID_OFFSET',
-            message: 'offset must be a non-negative integer',
-            details: { provided: offsetParam }
-          }
+            code: "INVALID_OFFSET",
+            message: "offset must be a non-negative integer",
+            details: { provided: offsetParam },
+          },
+        });
+      }
+      const parsedOffset = parseInt(offsetParam, 10);
+      if (isNaN(parsedOffset) || parsedOffset < 0) {
+        return res.status(400).json({
+          error: {
+            code: "INVALID_OFFSET",
+            message: "offset must be a non-negative integer",
+            details: { provided: offsetParam },
+          },
         });
       }
       offset = parsedOffset;
@@ -54,8 +73,10 @@ router.get("/", async (req, res) => {
 
     const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
     const category = typeof req.query.category === "string" ? req.query.category.trim() : "";
-    const status = typeof req.query.status === "string" ? req.query.status.trim().toLowerCase() : "";
-    const sort = typeof req.query.sort === "string" ? req.query.sort.trim().toLowerCase() : "newest";
+    const status =
+      typeof req.query.status === "string" ? req.query.status.trim().toLowerCase() : "";
+    const sort =
+      typeof req.query.sort === "string" ? req.query.sort.trim().toLowerCase() : "newest";
 
     const allowedStatuses = new Set(["", "active", "resolved", "ending_soon"]);
     if (!allowedStatuses.has(status)) {
@@ -113,7 +134,10 @@ router.get("/", async (req, res) => {
 
     const key = `markets:list:${JSON.stringify({ q, category, status, sort, limit, offset })}`;
     const data = await getOrSet(key, TTL.LIST, async () => {
-      const countResult = await db.query(`SELECT COUNT(*) as total FROM markets${whereSql}`, params);
+      const countResult = await db.query(
+        `SELECT COUNT(*) as total FROM markets${whereSql}`,
+        params
+      );
       const total = parseInt(countResult.rows[0].total, 10);
 
       const listParams = [...params, limit, offset];
@@ -146,43 +170,46 @@ router.get("/", async (req, res) => {
 // 2. rateLimitMarketCreation - enforces 3 markets per wallet per 24 hours
 router.post("/", validateMarketCreation, rateLimitMarketCreation, async (req, res) => {
   const { question, endDate, outcomes, contractAddress, walletAddress } = req.body;
-  
+
   // Basic required field validation (middleware handles detailed validation)
   if (!question || !endDate || !outcomes?.length || !walletAddress) {
-    return res.status(400).json({ 
+    return res.status(400).json({
       error: {
-        code: 'MISSING_REQUIRED_FIELDS',
-        message: 'question, endDate, outcomes, and walletAddress are required',
+        code: "MISSING_REQUIRED_FIELDS",
+        message: "question, endDate, outcomes, and walletAddress are required",
         details: {
           question: !!question,
           endDate: !!endDate,
           outcomes: !!outcomes?.length,
-          walletAddress: !!walletAddress
-        }
-      }
+          walletAddress: !!walletAddress,
+        },
+      },
     });
   }
-  
+
   try {
     // Market has passed all validation checks - create immediately without admin approval
     const result = await db.query(
       "INSERT INTO markets (question, end_date, outcomes, contract_address, created_at) VALUES ($1, $2, $3, $4, NOW()) RETURNING *",
       [question, endDate, outcomes, contractAddress || null]
     );
-    
-    logger.info({
-      market_id: result.rows[0].id,
-      question,
-      wallet_address: walletAddress,
-      contract_address: contractAddress,
-      outcomes_count: outcomes.length,
-      permissionless: true
-    }, "Market created via permissionless launch");
-    
+
+    logger.info(
+      {
+        market_id: result.rows[0].id,
+        question,
+        wallet_address: walletAddress,
+        contract_address: contractAddress,
+        outcomes_count: outcomes.length,
+        permissionless: true,
+      },
+      "Market created via permissionless launch"
+    );
+
     // Return 201 Created with the new market
-    res.status(201).json({ 
+    res.status(201).json({
       market: result.rows[0],
-      message: "Market created successfully and published immediately"
+      message: "Market created successfully and published immediately",
     });
 
     // Invalidate the market list cache so the new market appears immediately
@@ -197,12 +224,12 @@ router.post("/", validateMarketCreation, rateLimitMarketCreation, async (req, re
     });
   } catch (err) {
     logger.error({ err, question, wallet_address: walletAddress }, "Failed to create market");
-    res.status(500).json({ 
+    res.status(500).json({
       error: {
-        code: 'DATABASE_ERROR',
-        message: 'Failed to create market',
-        details: err.message
-      }
+        code: "DATABASE_ERROR",
+        message: "Failed to create market",
+        details: err.message,
+      },
     });
   }
 });
@@ -220,11 +247,14 @@ router.get("/:id", async (req, res) => {
       const bets = betsResult.rows;
       const confidenceScore = calculateConfidenceScore(bets);
 
-      logger.debug({
-        market_id: req.params.id,
-        bets_count: bets.length,
-        confidence_score: confidenceScore,
-      }, "Market details fetched with confidence score");
+      logger.debug(
+        {
+          market_id: req.params.id,
+          bets_count: bets.length,
+          confidence_score: confidenceScore,
+        },
+        "Market details fetched with confidence score"
+      );
 
       return { market: { ...market.rows[0], confidence_score: confidenceScore }, bets };
     });
@@ -238,6 +268,54 @@ router.get("/:id", async (req, res) => {
   } catch (err) {
     logger.error({ err, market_id: req.params.id }, "Failed to fetch market details");
     res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /api/markets/:id/bets — paginated order book rows for a single market
+router.get("/:id/bets", async (req, res) => {
+  const marketId = parseInt(req.params.id, 10);
+  const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
+  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 50, 1), 100);
+  const offset = (page - 1) * limit;
+
+  if (Number.isNaN(marketId)) {
+    return res.status(400).json({ error: "Invalid market id" });
+  }
+
+  try {
+    const countResult = await db.query("SELECT COUNT(*) AS total FROM bets WHERE market_id = $1", [
+      marketId,
+    ]);
+    const total = parseInt(countResult.rows[0]?.total ?? "0", 10);
+
+    const betsResult = await db.query(
+      `SELECT
+         b.id,
+         b.wallet_address,
+         b.outcome_index,
+         COALESCE(m.outcomes[b.outcome_index + 1], CONCAT('Option ', b.outcome_index + 1)) AS outcome_name,
+         b.amount,
+         b.created_at
+       FROM bets b
+       JOIN markets m ON m.id = b.market_id
+       WHERE b.market_id = $1
+       ORDER BY b.created_at DESC, b.id DESC
+       LIMIT $2 OFFSET $3`,
+      [marketId, limit, offset]
+    );
+
+    res.json({
+      bets: betsResult.rows,
+      meta: {
+        page,
+        limit,
+        total,
+        hasMore: offset + betsResult.rows.length < total,
+      },
+    });
+  } catch (err) {
+    logger.error({ err, market_id: marketId, page, limit }, "Failed to fetch market bets");
+    res.status(500).json({ error: "Failed to fetch market bets" });
   }
 });
 
@@ -258,7 +336,7 @@ router.get("/:id/odds", async (req, res) => {
     if (!marketResult.rows.length) {
       return res.status(404).json({ error: "Market not found" });
     }
-    
+
     // We assume there are multiple outcomes and we need to aggregate pools from 'bets'
     // Alternatively, if markets table maintains 'yes_pool' and 'no_pool', we would use those.
     // The previous implementation used total_pool. Let's calculate the pool per outcome index dynamically.
@@ -270,7 +348,7 @@ router.get("/:id/odds", async (req, res) => {
     const outcomesCount = marketResult.rows[0].outcomes ? marketResult.rows[0].outcomes.length : 2;
     const poolData = [];
     for (let i = 0; i < outcomesCount; i++) {
-      const b = betsResult.rows.find(row => parseInt(row.outcome_index) === i);
+      const b = betsResult.rows.find((row) => parseInt(row.outcome_index) === i);
       poolData.push({ index: i, pool: b ? parseFloat(b.pool) : 0 });
     }
 
@@ -278,7 +356,7 @@ router.get("/:id/odds", async (req, res) => {
     const odds = calculateOdds(poolData, total_pool);
 
     const responseData = { market_id: marketId, odds };
-    
+
     // Cache for 1 hour or until invalidated by a new bet
     await redis.set(cacheKey, JSON.stringify(responseData), "EX", 3600);
     logger.info({ market_id: marketId }, "Odds calculated and cached");
@@ -305,19 +383,25 @@ router.post("/:id/propose", async (req, res) => {
       logger.warn({ market_id: req.params.id }, "Market not found for proposal");
       return res.status(404).json({ error: "Market not found" });
     }
-    
-    logger.info({
-      market_id: req.params.id,
-      proposed_outcome: proposedOutcome,
-      status: "PROPOSED",
-    }, "Market resolution proposed");
-    
+
+    logger.info(
+      {
+        market_id: req.params.id,
+        proposed_outcome: proposedOutcome,
+        status: "PROPOSED",
+      },
+      "Market resolution proposed"
+    );
+
     // Trigger notification
     triggerNotification(req.params.id, "PROPOSED");
 
     res.json({ market: result.rows[0] });
   } catch (err) {
-    logger.error({ err, market_id: req.params.id, proposed_outcome: proposedOutcome }, "Failed to propose market resolution");
+    logger.error(
+      { err, market_id: req.params.id, proposed_outcome: proposedOutcome },
+      "Failed to propose market resolution"
+    );
     res.status(500).json({ error: err.message });
   }
 });
@@ -337,13 +421,16 @@ router.post("/:id/resolve", async (req, res) => {
       logger.warn({ market_id: req.params.id }, "Market not found for resolution");
       return res.status(404).json({ error: "Market not found" });
     }
-    
-    logger.info({
-      market_id: req.params.id,
-      winning_outcome: winningOutcome,
-      status: "RESOLVED",
-    }, "Market resolved");
-    
+
+    logger.info(
+      {
+        market_id: req.params.id,
+        winning_outcome: winningOutcome,
+        status: "RESOLVED",
+      },
+      "Market resolved"
+    );
+
     // Invalidate both the detail cache and the list cache on resolution
     await invalidateAll(req.params.id);
 
@@ -352,7 +439,10 @@ router.post("/:id/resolve", async (req, res) => {
 
     res.json({ market: result.rows[0] });
   } catch (err) {
-    logger.error({ err, market_id: req.params.id, winning_outcome: winningOutcome }, "Failed to resolve market");
+    logger.error(
+      { err, market_id: req.params.id, winning_outcome: winningOutcome },
+      "Failed to resolve market"
+    );
     res.status(500).json({ error: err.message });
   }
 });

--- a/backend/src/tests/index.test.js
+++ b/backend/src/tests/index.test.js
@@ -1,0 +1,56 @@
+"use strict";
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+jest.mock("firebase-admin", () => ({ apps: [true], initializeApp: jest.fn() }), { virtual: true });
+jest.mock("../middleware/appCheck", () => (req, res, next) => next());
+
+const request = require("supertest");
+const express = require("express");
+const { applyCommonMiddleware, applyErrorHandlers } = require("../index");
+
+function buildApp() {
+  const app = express();
+  applyCommonMiddleware(app);
+  app.post("/echo", (req, res) => {
+    res.json({ received: req.body.payload?.length ?? 0 });
+  });
+  applyErrorHandlers(app);
+  return app;
+}
+
+describe("request body size limits", () => {
+  it("accepts payloads within the 10kb limit", async () => {
+    const app = buildApp();
+    const payload = "a".repeat(9 * 1024);
+
+    const res = await request(app).post("/echo").send({ payload });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: payload.length });
+  });
+
+  it("returns 413 for JSON bodies larger than 10kb", async () => {
+    const app = buildApp();
+    const payload = "a".repeat(11 * 1024);
+
+    const res = await request(app).post("/echo").send({ payload });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toEqual({ error: "Request body exceeds the 10kb limit." });
+  });
+
+  it("does not expose internal parser details in the 413 response", async () => {
+    const app = buildApp();
+    const payload = "a".repeat(11 * 1024);
+
+    const res = await request(app).post("/echo").send({ payload });
+
+    expect(JSON.stringify(res.body)).not.toContain("entity.too.large");
+    expect(JSON.stringify(res.body)).not.toContain("PayloadTooLargeError");
+  });
+});

--- a/contracts/prediction_market/src/events.rs
+++ b/contracts/prediction_market/src/events.rs
@@ -36,6 +36,24 @@ pub struct EventContractInitialized {
     pub ledger_timestamp: u64,
 }
 
+/// Emitted by `pause`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventContractPaused {
+    pub version: u32,
+    pub pauser: Address,
+    pub ledger_timestamp: u64,
+}
+
+/// Emitted by `unpause`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventContractUnpaused {
+    pub version: u32,
+    pub pauser: Address,
+    pub ledger_timestamp: u64,
+}
+
 /// Emitted by `create_market`.
 #[contracttype]
 #[derive(Clone)]
@@ -179,6 +197,16 @@ pub struct EventFeeRateUpdated {
     pub ledger_timestamp: u64,
 }
 
+/// Emitted by `set_min_bet`.
+#[contracttype]
+#[derive(Clone)]
+pub struct EventMinBetUpdated {
+    pub version: u32,
+    pub old_min: i128,
+    pub new_min: i128,
+    pub ledger_timestamp: u64,
+}
+
 /// Emitted by `create_market` when a non-zero creation fee is collected.
 #[contracttype]
 #[derive(Clone)]
@@ -200,6 +228,28 @@ pub fn emit_contract_initialized(env: &Env, admin: &Address) {
         EventContractInitialized {
             version: EVENT_VERSION,
             admin: admin.clone(),
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_contract_paused(env: &Env, pauser: &Address) {
+    env.events().publish(
+        (symbol_short!("CtrPause"),),
+        EventContractPaused {
+            version: EVENT_VERSION,
+            pauser: pauser.clone(),
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_contract_unpaused(env: &Env, pauser: &Address) {
+    env.events().publish(
+        (symbol_short!("CtrUnps"),),
+        EventContractUnpaused {
+            version: EVENT_VERSION,
+            pauser: pauser.clone(),
             ledger_timestamp: env.ledger().timestamp(),
         },
     );
@@ -406,6 +456,18 @@ pub fn emit_fee_rate_updated(env: &Env, old_rate_bps: u32, new_rate_bps: u32) {
             version: EVENT_VERSION,
             old_rate_bps,
             new_rate_bps,
+            ledger_timestamp: env.ledger().timestamp(),
+        },
+    );
+}
+
+pub fn emit_min_bet_updated(env: &Env, old_min: i128, new_min: i128) {
+    env.events().publish(
+        (symbol_short!("MinBetUp"),),
+        EventMinBetUpdated {
+            version: EVENT_VERSION,
+            old_min,
+            new_min,
             ledger_timestamp: env.ledger().timestamp(),
         },
     );

--- a/contracts/prediction_market/src/lib.rs
+++ b/contracts/prediction_market/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 #[cfg(test)]
-use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::testutils::{Address as _, Events as _, Ledger as _};
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token, vec, Address, BytesN, Env, Map, String, Vec, IntoVal,
 };
@@ -19,6 +19,7 @@ use crate::events::{
     emit_fee_rate_updated, emit_lp_reward_claimed, emit_liquidity_provided,
     emit_market_created, emit_market_paused, emit_market_resolved, emit_market_voided,
     emit_market_voided_no_winner, emit_batch_payout_claimed, emit_payout_claimed,
+    emit_contract_paused, emit_contract_unpaused, emit_min_bet_updated,
 };
 mod lmsr;
 mod position_token;
@@ -114,6 +115,7 @@ pub const MAX_ORACLE_DRIFT: u64 = 1800;
 #[contracttype]
 pub enum DataKey {
     Initialized,
+    Paused,
     OracleAddress,
     Market(u64),
     Bets(u64),
@@ -254,6 +256,11 @@ fn load_outcome_shares(env: &Env, market_id: u64) -> Vec<i128> {
         .instance()
         .get(&DataKey::OutcomeShares(market_id))
         .unwrap()
+}
+
+fn require_not_paused(env: &Env) {
+    let paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
+    assert!(!paused, "contract is paused");
 }
 
 fn build_share_arrays(outcome_shares: &Vec<i128>) -> ([i128; 8], usize) {
@@ -578,7 +585,9 @@ impl PredictionMarket {
         admin.require_auth();
         env.storage().instance().set(&DataKey::Initialized, &true);
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
         env.storage().instance().set(&DataKey::FeeRateBps, &300u32);
+        env.storage().instance().set(&DataKey::MinBetAmount, &10_000_000i128);
         env.storage().instance().extend_ttl(LEDGER_TTL_EXTEND / 2, LEDGER_TTL_EXTEND);
         // Bootstrap SuperAdmin in Persistent storage (new role system)
         bootstrap_super_admin(&env, &admin);
@@ -586,6 +595,27 @@ impl PredictionMarket {
         set_role(&env, AccessRole::Admin, &admin);
         set_platform_status(&env, AccessPlatformStatus::Active);
         emit_contract_initialized(&env, &admin);
+    }
+
+    /// Toggle the emergency contract pause on. Blocks new bets and payout claims.
+    pub fn pause(env: Env, caller: Address) {
+        require_role(&env, &caller, Role::Pauser);
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.storage().instance().extend_ttl(LEDGER_TTL_EXTEND / 2, LEDGER_TTL_EXTEND);
+        emit_contract_paused(&env, &caller);
+    }
+
+    /// Toggle the emergency contract pause off.
+    pub fn unpause(env: Env, caller: Address) {
+        require_role(&env, &caller, Role::Pauser);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage().instance().extend_ttl(LEDGER_TTL_EXTEND / 2, LEDGER_TTL_EXTEND);
+        emit_contract_unpaused(&env, &caller);
+    }
+
+    /// Read the emergency contract pause flag.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
     }
 
     /// Assign a role to an address. Only SuperAdmin may call this.
@@ -768,6 +798,7 @@ impl PredictionMarket {
     /// Typical markets have <100 bettors, making Vec O(n) faster than Map O(1) with hashing overhead.
     pub fn place_bet(env: Env, market_id: u64, option_index: u32, bettor: Address, amount: i128) {
         check_platform_active(&env);
+        require_not_paused(&env);
         bettor.require_auth();
         Self::internal_place_bet(env, market_id, option_index, bettor, amount);
     }
@@ -788,6 +819,7 @@ impl PredictionMarket {
         signature: soroban_sdk::BytesN<64>,
     ) {
         check_platform_active(&env);
+        require_not_paused(&env);
 
         // 1. Verify manual nonce (Replay Protection Requirement #209)
         let stored_nonce: u64 = env
@@ -823,8 +855,8 @@ impl PredictionMarket {
             .storage()
             .instance()
             .get(&DataKey::MinBetAmount)
-            .unwrap_or(1i128); // default 1 for tests; production should set explicitly
-        assert!(amount >= min_bet, "bet below minimum");
+            .unwrap_or(10_000_000i128);
+        assert!(amount >= min_bet, "bet amount is below the minimum of 1 XLM");
 
         let max_bet: i128 = env
             .storage()
@@ -1176,9 +1208,33 @@ impl PredictionMarket {
         env.storage().instance().extend_ttl(LEDGER_TTL_EXTEND / 2, LEDGER_TTL_EXTEND);
     }
 
+    /// Update only the minimum bet amount. FeeSetter role only.
+    pub fn set_min_bet(env: Env, caller: Address, new_min: i128) {
+        caller.require_auth();
+        require_role(&env, &caller, Role::FeeSetter);
+        assert!(
+            new_min > 0 && new_min <= 1_000_000_000i128,
+            "invalid minimum bet amount"
+        );
+
+        let old_min: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinBetAmount)
+            .unwrap_or(10_000_000i128);
+
+        env.storage().instance().set(&DataKey::MinBetAmount, &new_min);
+        env.storage().instance().extend_ttl(LEDGER_TTL_EXTEND / 2, LEDGER_TTL_EXTEND);
+        emit_min_bet_updated(&env, old_min, new_min);
+    }
+
     /// Get current bet limits. Returns (min_amount, max_amount).
     pub fn get_bet_limits(env: Env) -> (i128, i128) {
-        let min: i128 = env.storage().instance().get(&DataKey::MinBetAmount).unwrap_or(1);
+        let min: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinBetAmount)
+            .unwrap_or(10_000_000i128);
         let max: i128 = env.storage().instance().get(&DataKey::MaxBetAmount).unwrap_or(i128::MAX);
         (min, max)
     }
@@ -2201,6 +2257,7 @@ impl PredictionMarket {
     /// Calculates payout in O(1) using per-outcome pool tracking.
     pub fn claim_payout(env: Env, market_id: u64, claimant: Address) -> i128 {
         claimant.require_auth();
+        require_not_paused(&env);
 
         // Acquire re-entrancy lock
         acquire_reentrancy_lock(&env);
@@ -2629,6 +2686,11 @@ mod tests {
     use soroban_sdk::testutils::Address as _;
 
     fn setup() -> (Env, PredictionMarketClient<'static>, Address, Address, u64) {
+        let (env, client, _admin, creator, token_addr, deadline) = setup_with_admin();
+        (env, client, creator, token_addr, deadline)
+    }
+
+    fn setup_with_admin() -> (Env, PredictionMarketClient<'static>, Address, Address, Address, u64) {
         let env = Env::default();
         env.mock_all_auths();
 
@@ -2676,7 +2738,7 @@ mod tests {
             &fee_dest.clone()
         );
 
-        (env, client, creator, token_addr, deadline)
+        (env, client, admin, creator, token_addr, deadline)
     }
 
     fn setup_market_with_winners(n: u32) -> (Env, PredictionMarketClient<'static>, Vec<Address>) {
@@ -2896,30 +2958,86 @@ mod tests {
         assert!(client.get_total_shares(&2u64) > 0);
     }
 
-    // ── Instance storage: is_paused ───────────────────────────────────────────
+    // ── Instance storage: emergency contract pause ───────────────────────────
 
     #[test]
-    fn test_is_paused_defaults_false() {
+    fn test_contract_pause_defaults_false() {
         let (_, client, _, _, _) = setup();
-        assert!(!client.get_is_paused(&1u64));
+        assert!(!client.is_paused());
     }
 
     #[test]
-    fn test_set_paused_updates_instance_storage() {
-        let (_, client, _, _, _) = setup();
-        client.set_paused(&1u64, &true);
-        assert!(client.get_is_paused(&1u64));
-        client.set_paused(&1u64, &false);
-        assert!(!client.get_is_paused(&1u64));
+    fn test_pause_and_unpause_update_instance_storage() {
+        let (env, client, admin, _, _, _) = setup_with_admin();
+        let pauser = Address::generate(&env);
+
+        client.assign_role(&admin, &pauser, &Role::Pauser);
+
+        client.pause(&pauser);
+        assert!(client.is_paused());
+
+        client.unpause(&pauser);
+        assert!(!client.is_paused());
     }
 
     #[test]
-    #[should_panic(expected = "Market is paused")]
-    fn test_place_bet_blocked_when_paused() {
+    #[should_panic(expected = "caller does not hold role Pauser")]
+    fn test_only_pauser_can_toggle_contract_pause() {
         let (env, client, _, _, _) = setup();
-        client.set_paused(&1u64, &true);
+        let caller = Address::generate(&env);
+        client.pause(&caller);
+    }
+
+    #[test]
+    #[should_panic(expected = "contract is paused")]
+    fn test_place_bet_blocked_when_contract_paused() {
+        let (env, client, admin, _, token, _) = setup_with_admin();
+        let pauser = Address::generate(&env);
         let bettor = Address::generate(&env);
+
+        client.assign_role(&admin, &pauser, &Role::Pauser);
+        client.pause(&pauser);
+
+        let sac = token::StellarAssetClient::new(&env, &token);
+        sac.mint(&bettor, &10_000_000i128);
+
         client.place_bet(&1u64, &0u32, &bettor, &50i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "contract is paused")]
+    fn test_claim_payout_blocked_when_contract_paused() {
+        let (env, client, admin, _, token, _) = setup_with_admin();
+        let pauser = Address::generate(&env);
+        let bettor = Address::generate(&env);
+
+        client.assign_role(&admin, &pauser, &Role::Pauser);
+
+        let sac = token::StellarAssetClient::new(&env, &token);
+        sac.mint(&bettor, &10_000_000i128);
+
+        client.place_bet(&1u64, &0u32, &bettor, &1_000_000i128);
+        client.propose_resolution(&1u64, &0u32);
+        env.ledger().with_mut(|l| l.timestamp += LIVENESS_WINDOW + 86400 + 1);
+        client.resolve_market(&1u64, &0u32);
+
+        client.pause(&pauser);
+        client.claim_payout(&1u64, &bettor);
+    }
+
+    #[test]
+    fn test_pause_and_unpause_emit_events() {
+        let (env, client, admin, _, _, _) = setup_with_admin();
+        let pauser = Address::generate(&env);
+
+        client.assign_role(&admin, &pauser, &Role::Pauser);
+
+        client.pause(&pauser);
+        client.unpause(&pauser);
+
+        let events_debug = format!("{:?}", env.events().all());
+        assert!(events_debug.contains("CtrPause"));
+        assert!(events_debug.contains("CtrUnps"));
     }
 
     // ── Persistent storage: UserPosition ─────────────────────────────────────
@@ -3618,6 +3736,51 @@ mod tests {
     }
 
     #[test]
+    fn test_default_min_bet_is_one_xlm_after_initialize() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(PredictionMarket, ());
+        let client = PredictionMarketClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.initialize(&admin);
+
+        let (min, _) = client.get_bet_limits();
+        assert_eq!(min, 10_000_000i128);
+    }
+
+    #[test]
+    fn test_set_min_bet_updates_minimum() {
+        let (env, client, admin, _, _, _) = setup_with_admin();
+        let fee_setter = Address::generate(&env);
+
+        client.assign_role(&admin, &fee_setter, &Role::FeeSetter);
+        client.set_min_bet(&fee_setter, &25_000_000i128);
+
+        let (min, _) = client.get_bet_limits();
+        assert_eq!(min, 25_000_000i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "AccessDenied: caller does not hold role FeeSetter")]
+    fn test_only_fee_setter_can_update_min_bet() {
+        let (env, client, _, _, _, _) = setup_with_admin();
+        let caller = Address::generate(&env);
+        client.set_min_bet(&caller, &25_000_000i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid minimum bet amount")]
+    fn test_set_min_bet_rejects_value_above_100_xlm() {
+        let (env, client, admin, _, _, _) = setup_with_admin();
+        let fee_setter = Address::generate(&env);
+
+        client.assign_role(&admin, &fee_setter, &Role::FeeSetter);
+        client.set_min_bet(&fee_setter, &1_000_000_001i128);
+    }
+
+    #[test]
     #[should_panic(expected = "bet exceeds cap")]
     fn test_bet_above_max_panics() {
         let (env, client, _, _, _) = setup();
@@ -3627,7 +3790,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "bet below minimum")]
+    #[should_panic(expected = "bet amount is below the minimum of 1 XLM")]
     fn test_bet_below_min_panics() {
         let (env, client, _, _, _) = setup();
         client.update_bet_limits(&5_000_000i128, &100_000_000i128);
@@ -4605,6 +4768,3 @@ mod tests {
         assert_eq!(client.get_audit_hash(&1u64), hash2);
     }
 }
-
-
-

--- a/docs/implementation/api-docs.md
+++ b/docs/implementation/api-docs.md
@@ -36,3 +36,21 @@ Reports the health of the Application layer, the Database (Postgres), and the St
 **Status Codes:**
 - `200 OK`: When system is `up` or `degraded`.
 - `503 Service Unavailable`: When system is completely `down` (both core services unreachable).
+
+## Request Body Limits
+
+All backend endpoints that use JSON or URL-encoded request parsing enforce an explicit **10kb request body limit**.
+
+- `express.json({ limit: "10kb" })`
+- `express.urlencoded({ extended: true, limit: "10kb" })`
+
+Oversized request bodies are rejected with:
+
+```json
+{
+  "error": "Request body exceeds the 10kb limit."
+}
+```
+
+**Status Code:**
+- `413 Payload Too Large`: Request body exceeded the 10kb parsing limit.

--- a/frontend/src/app/market/[id]/MarketDetailPage.tsx
+++ b/frontend/src/app/market/[id]/MarketDetailPage.tsx
@@ -4,12 +4,15 @@ import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { useWallet } from "../../../hooks/useWallet";
-import { formatWallet, formatRelativeTime } from "../../../hooks/useRecentActivity";
+import { formatWallet } from "../../../hooks/useRecentActivity";
 import MobileShell from "../../../components/mobile/MobileShell";
 import OddsTicker from "../../../components/OddsTicker";
 import BetConfirmationModal from "../../../components/BetConfirmationModal";
+import StakePresets from "../../../components/StakePresets";
 import { useMarket } from "../../../hooks/useMarket";
 import { usePlaceBet } from "../../../hooks/usePlaceBet";
+import VirtualizedOrderBook from "../../../components/VirtualizedOrderBook";
+import { useOrderBook } from "../../../hooks/useOrderBook";
 
 // =============================================================================
 // Types
@@ -312,50 +315,32 @@ function PositionsTab({ positions, outcomes }: PositionsTabProps) {
 }
 
 interface ActivityTabProps {
-  bets: Bet[];
+  marketId: number;
   outcomes: string[];
 }
 
-function ActivityTab({ bets, outcomes }: ActivityTabProps) {
-  if (bets.length === 0) {
+function ActivityTab({ marketId, outcomes }: ActivityTabProps) {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
+  const { rows, error, hasMore, loadMore } = useOrderBook(apiUrl, marketId);
+
+  if (error && rows.length === 0) {
     return (
       <div className="bg-gray-900 rounded-xl p-8 border border-gray-800 text-center">
-        <p className="text-gray-400">No activity yet</p>
+        <p className="text-red-400">Failed to load activity.</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-      <div className="divide-y divide-gray-800">
-        {bets.map((bet) => (
-          <div key={bet.id} className="p-4 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div
-                className={`w-10 h-10 rounded-full flex items-center justify-center font-bold ${
-                  bet.outcome_index === 0
-                    ? "bg-green-900 text-green-300"
-                    : "bg-red-900 text-red-300"
-                }`}
-              >
-                {outcomes[bet.outcome_index]?.[0] || "?"}
-              </div>
-              <div>
-                <p className="text-white font-medium">
-                  <span className="font-mono text-sm">{formatWallet(bet.wallet_address)}</span>
-                  <span className="text-gray-400 ml-2 text-sm">
-                    bet on {outcomes[bet.outcome_index] || `Option ${bet.outcome_index + 1}`}
-                  </span>
-                </p>
-                <p className="text-gray-500 text-xs">{formatRelativeTime(bet.created_at)}</p>
-              </div>
-            </div>
-            <div className="text-right">
-              <p className="text-white font-semibold">{parseFloat(bet.amount).toFixed(2)} XLM</p>
-            </div>
-          </div>
-        ))}
-      </div>
+    <div className="space-y-3">
+      <VirtualizedOrderBook
+        marketId={marketId}
+        outcomes={outcomes}
+        initialRows={rows}
+        onLoadMore={loadMore}
+        hasMore={hasMore}
+      />
+      {error ? <p className="text-xs text-gray-500">{error}</p> : null}
     </div>
   );
 }
@@ -370,14 +355,13 @@ interface BettingPanelProps {
   onBetPlaced: () => void;
 }
 
-const HORIZON = "https://horizon-testnet.stellar.org";
-
 function BettingPanel({ market, odds, onBetPlaced }: BettingPanelProps) {
   const { publicKey, connecting, connect } = useWallet();
   const [selectedOutcome, setSelectedOutcome] = useState<number | null>(null);
   const [amount, setAmount] = useState("");
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const xlmBalance = null;
 
   const betMutation = usePlaceBet(market.id);
 
@@ -534,6 +518,7 @@ function BettingPanel({ market, odds, onBetPlaced }: BettingPanelProps) {
           {message.text}
         </div>
       )}
+      <div className="md:hidden pt-4">{/* Mobile Spacer */}</div>
 
       {selectedOutcome !== null && (
         <BetConfirmationModal
@@ -710,7 +695,9 @@ export default function MarketDetailPage({ marketId }: MarketDetailPageProps) {
             {activeTab === "positions" && (
               <PositionsTab positions={positions} outcomes={market.outcomes} />
             )}
-            {activeTab === "activity" && <ActivityTab bets={bets} outcomes={market.outcomes} />}
+            {activeTab === "activity" && (
+              <ActivityTab marketId={market.id} outcomes={market.outcomes} />
+            )}
 
             {/* Mobile Sticky Betting Panel */}
             <div className="fixed bottom-0 left-0 right-0 bg-gray-950 border-t border-gray-800 p-4 md:static md:mt-6 md:bg-transparent md:border-0 md:p-0 z-20">

--- a/frontend/src/components/VirtualizedOrderBook.tsx
+++ b/frontend/src/components/VirtualizedOrderBook.tsx
@@ -23,7 +23,7 @@
  *     next page and append to dataRef.
  */
 import { useRef, useCallback, useEffect, useState } from "react";
-import { FixedSizeList, ListChildComponentProps, ListOnItemsRenderedProps } from "react-window";
+import { FixedSizeList, ListChildComponentProps } from "react-window";
 import { formatWallet, formatRelativeTime } from "../hooks/useRecentActivity";
 
 /** Height of each row in pixels — must be fixed for FixedSizeList */
@@ -31,9 +31,6 @@ export const ITEM_SIZE = 48;
 
 /** Height of the visible scrolling window in pixels */
 export const LIST_HEIGHT = 400;
-
-/** Fetch next page when this many rows remain before the end */
-const PREFETCH_THRESHOLD = 10;
 
 export interface OrderBookRow {
   id: number;
@@ -49,8 +46,9 @@ interface Props {
   outcomes: string[];
   /** Initial rows (first page) */
   initialRows?: OrderBookRow[];
-  /** Called when the user scrolls near the bottom; should return the next page */
+  /** Called when the user requests the next page */
   onLoadMore?: (page: number) => Promise<OrderBookRow[]>;
+  hasMore?: boolean;
 }
 
 /** Outcome badge colours cycle through a small palette */
@@ -66,23 +64,47 @@ export default function VirtualizedOrderBook({
   outcomes,
   initialRows = [],
   onLoadMore,
+  hasMore = false,
 }: Props) {
-  // Hold rows in a ref so appends don't trigger a full re-render
-  const dataRef = useRef<OrderBookRow[]>(initialRows);
+  // Hold rows in a ref so prepends/appends do not force a full re-render of existing rows.
+  const dataRef = useRef<OrderBookRow[]>([]);
+  const knownIdsRef = useRef<Set<number>>(new Set());
   // itemCount drives react-window's scroll math — update this to trigger a repaint
-  const [itemCount, setItemCount] = useState(initialRows.length);
+  const [itemCount, setItemCount] = useState(0);
   const [loadingMore, setLoadingMore] = useState(false);
   const pageRef = useRef(1);
 
   // react-window list ref — used to imperatively scroll if needed
   const listRef = useRef<FixedSizeList>(null);
 
-  // Sync dataRef when initialRows prop changes (e.g. first API response arrives)
+  // Reset the order book when the market changes.
   useEffect(() => {
     dataRef.current = initialRows;
+    knownIdsRef.current = new Set(initialRows.map((row) => row.id));
     setItemCount(initialRows.length);
-    // FixedSizeList re-renders automatically when itemCount state changes;
-    // no resetAfterIndex needed (that's a VariableSizeList API).
+    pageRef.current = 1;
+  }, [marketId]);
+
+  // Live prepends: only prepend truly new rows pushed in from polling.
+  useEffect(() => {
+    if (initialRows.length === 0) {
+      if (dataRef.current.length === 0) setItemCount(0);
+      return;
+    }
+
+    const incoming = initialRows.filter((row) => !knownIdsRef.current.has(row.id));
+    if (dataRef.current.length === 0) {
+      dataRef.current = initialRows;
+      knownIdsRef.current = new Set(initialRows.map((row) => row.id));
+      setItemCount(initialRows.length);
+      return;
+    }
+
+    if (incoming.length === 0) return;
+
+    incoming.forEach((row) => knownIdsRef.current.add(row.id));
+    dataRef.current = [...incoming, ...dataRef.current];
+    setItemCount(dataRef.current.length);
   }, [initialRows]);
 
   /**
@@ -91,35 +113,30 @@ export default function VirtualizedOrderBook({
    * while existing rows keep their cached layout (fixed height = no remeasure).
    */
   const appendRows = useCallback((newRows: OrderBookRow[]) => {
-    dataRef.current = [...dataRef.current, ...newRows];
+    const unseenRows = newRows.filter((row) => !knownIdsRef.current.has(row.id));
+    if (unseenRows.length === 0) return;
+    unseenRows.forEach((row) => knownIdsRef.current.add(row.id));
+    dataRef.current = [...dataRef.current, ...unseenRows];
     // Updating itemCount is sufficient — FixedSizeList recalculates scroll
     // height from itemCount * itemSize without touching existing rows.
     setItemCount(dataRef.current.length);
   }, []);
 
-  /**
-   * Infinite scroll handler — fires on every visible-window change.
-   * Fetches the next page when the user is within PREFETCH_THRESHOLD rows of the end.
-   */
-  const handleItemsRendered = useCallback(
-    async ({ visibleStopIndex }: ListOnItemsRenderedProps) => {
-      if (!onLoadMore || loadingMore) return;
-      if (visibleStopIndex >= dataRef.current.length - PREFETCH_THRESHOLD) {
-        setLoadingMore(true);
-        try {
-          const nextPage = pageRef.current + 1;
-          const rows = await onLoadMore(nextPage);
-          if (rows.length > 0) {
-            pageRef.current = nextPage;
-            appendRows(rows);
-          }
-        } finally {
-          setLoadingMore(false);
-        }
+  const handleLoadMore = useCallback(async () => {
+    if (!onLoadMore || loadingMore || !hasMore) return;
+
+    setLoadingMore(true);
+    try {
+      const nextPage = pageRef.current + 1;
+      const rows = await onLoadMore(nextPage);
+      if (rows.length > 0) {
+        pageRef.current = nextPage;
+        appendRows(rows);
       }
-    },
-    [onLoadMore, loadingMore, appendRows]
-  );
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [appendRows, hasMore, loadingMore, onLoadMore]);
 
   /** Row renderer — called by react-window for each visible row only */
   const Row = useCallback(
@@ -127,7 +144,8 @@ export default function VirtualizedOrderBook({
       const row = dataRef.current[index];
       if (!row) return null;
 
-      const outcomeName = row.outcome_name || outcomes[row.outcome_index] || `#${row.outcome_index}`;
+      const outcomeName =
+        row.outcome_name || outcomes[row.outcome_index] || `#${row.outcome_index}`;
       const badgeColor = BADGE_COLORS[row.outcome_index % BADGE_COLORS.length];
 
       return (
@@ -175,7 +193,10 @@ export default function VirtualizedOrderBook({
   }
 
   return (
-    <div data-testid="virtualized-order-book" className="rounded-xl border border-gray-800 overflow-hidden">
+    <div
+      data-testid="virtualized-order-book"
+      className="rounded-xl border border-gray-800 overflow-hidden"
+    >
       {/* Header */}
       <div className="flex items-center gap-3 px-4 py-2 bg-gray-800/60 text-xs text-gray-400 font-medium">
         <span className="w-20 shrink-0">Wallet</span>
@@ -195,21 +216,33 @@ export default function VirtualizedOrderBook({
         width="100%"
         itemCount={itemCount}
         itemSize={ITEM_SIZE}
-        onItemsRendered={handleItemsRendered}
         data-testid="order-book-list"
       >
         {Row}
       </FixedSizeList>
 
-      {/* Loading indicator shown while fetching next page */}
-      {loadingMore && (
-        <div
-          data-testid="order-book-loading"
-          className="flex items-center justify-center py-2 text-xs text-gray-500"
-        >
-          Loading more…
-        </div>
-      )}
+      <div className="border-t border-gray-800/60 bg-gray-900/80 p-3">
+        {loadingMore && (
+          <div
+            data-testid="order-book-loading"
+            className="flex items-center justify-center py-2 text-xs text-gray-500"
+          >
+            Loading more...
+          </div>
+        )}
+
+        {onLoadMore && hasMore ? (
+          <button
+            type="button"
+            data-testid="order-book-load-more"
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            className="w-full rounded-lg border border-gray-700 px-3 py-2 text-sm font-medium text-gray-200 transition-colors hover:border-gray-500 hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {loadingMore ? "Loading..." : "Load more"}
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/__tests__/VirtualizedOrderBook.test.tsx
+++ b/frontend/src/components/__tests__/VirtualizedOrderBook.test.tsx
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  *
  * Unit tests for VirtualizedOrderBook component.
- * Covers: rendering, empty state, row content, live updates (appendRows),
- * infinite scroll trigger, loading indicator, 500+ row dataset.
+ * Covers: rendering, empty state, row content, live prepends,
+ * explicit load-more behavior, loading indicator, 500+ row dataset.
  */
 import React from "react";
 import { render, screen, act, fireEvent } from "@testing-library/react";
@@ -21,24 +21,11 @@ import VirtualizedOrderBook, {
 
 jest.mock("react-window", () => ({
   FixedSizeList: React.forwardRef(function MockFixedSizeList(
-    { children: RowRenderer, itemCount, itemSize, height, onItemsRendered }: any,
+    { children: RowRenderer, itemCount, itemSize, height }: any,
     _ref: any
   ) {
     // Simulate the visible window: render up to 20 items (enough for tests)
     const visibleCount = Math.min(itemCount, 20);
-
-    // Fire onItemsRendered so infinite-scroll logic can be tested
-    React.useEffect(() => {
-      if (onItemsRendered && itemCount > 0) {
-        onItemsRendered({
-          overscanStartIndex: 0,
-          overscanStopIndex: visibleCount - 1,
-          visibleStartIndex: 0,
-          visibleStopIndex: visibleCount - 1,
-        });
-      }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [itemCount]);
 
     return (
       <div data-testid="order-book-list" style={{ height, overflow: "auto" }}>
@@ -102,21 +89,13 @@ describe("VirtualizedOrderBook", () => {
   });
 
   it("renders the FixedSizeList", () => {
-    render(
-      <VirtualizedOrderBook
-        marketId={1}
-        outcomes={OUTCOMES}
-        initialRows={[makeRow(1)]}
-      />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[makeRow(1)]} />);
     expect(screen.getByTestId("order-book-list")).toBeInTheDocument();
   });
 
   it("renders a row for each visible item", () => {
     const rows = [makeRow(1), makeRow(2), makeRow(3)];
-    render(
-      <VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={rows} />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={rows} />);
     expect(screen.getByTestId("order-row-1")).toBeInTheDocument();
     expect(screen.getByTestId("order-row-2")).toBeInTheDocument();
     expect(screen.getByTestId("order-row-3")).toBeInTheDocument();
@@ -125,64 +104,36 @@ describe("VirtualizedOrderBook", () => {
   // ── Row content ────────────────────────────────────────────────────────────
 
   it("displays abbreviated wallet address", () => {
-    render(
-      <VirtualizedOrderBook
-        marketId={1}
-        outcomes={OUTCOMES}
-        initialRows={[makeRow(1)]}
-      />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[makeRow(1)]} />);
     // GABC00000001XYZ → GABC…0XYZ (first 4 + last 4)
     expect(screen.getByText(/GABC/)).toBeInTheDocument();
   });
 
   it("displays outcome badge", () => {
-    render(
-      <VirtualizedOrderBook
-        marketId={1}
-        outcomes={OUTCOMES}
-        initialRows={[makeRow(1, 0)]}
-      />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[makeRow(1, 0)]} />);
     expect(screen.getByText("Yes")).toBeInTheDocument();
   });
 
   it("displays XLM amount", () => {
-    render(
-      <VirtualizedOrderBook
-        marketId={1}
-        outcomes={OUTCOMES}
-        initialRows={[makeRow(1)]}
-      />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[makeRow(1)]} />);
     expect(screen.getByText("10.00 XLM")).toBeInTheDocument();
   });
 
   it("displays relative timestamp", () => {
-    render(
-      <VirtualizedOrderBook
-        marketId={1}
-        outcomes={OUTCOMES}
-        initialRows={[makeRow(1)]}
-      />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[makeRow(1)]} />);
     // Row 1 was created 1s ago
     expect(screen.getByText(/ago|just now/)).toBeInTheDocument();
   });
 
   it("uses outcome_name when provided", () => {
     const row: OrderBookRow = { ...makeRow(1), outcome_name: "Draw" };
-    render(
-      <VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[row]} />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[row]} />);
     expect(screen.getByText("Draw")).toBeInTheDocument();
   });
 
   it("falls back to outcomes array when outcome_name is empty", () => {
     const row: OrderBookRow = { ...makeRow(1, 1), outcome_name: "" };
-    render(
-      <VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[row]} />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[row]} />);
     expect(screen.getByText("No")).toBeInTheDocument();
   });
 
@@ -190,9 +141,7 @@ describe("VirtualizedOrderBook", () => {
 
   it("renders 500+ rows without crashing", () => {
     const rows = make500Rows();
-    render(
-      <VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={rows} />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={rows} />);
     expect(screen.getByTestId("virtualized-order-book")).toBeInTheDocument();
     // Only up to 20 rows are rendered by the mock (virtualization)
     expect(screen.getByTestId("order-row-1")).toBeInTheDocument();
@@ -200,9 +149,7 @@ describe("VirtualizedOrderBook", () => {
 
   it("only renders a windowed subset of 500 rows (virtualization)", () => {
     const rows = make500Rows();
-    render(
-      <VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={rows} />
-    );
+    render(<VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={rows} />);
     // Mock renders max 20 — row 21 should NOT be in the DOM
     expect(screen.queryByTestId("order-row-21")).not.toBeInTheDocument();
     expect(screen.getByTestId("order-row-1")).toBeInTheDocument();
@@ -218,64 +165,107 @@ describe("VirtualizedOrderBook", () => {
     expect(LIST_HEIGHT).toBe(400);
   });
 
-  // ── Infinite scroll ────────────────────────────────────────────────────────
+  // ── Live prepends ─────────────────────────────────────────────────────────
 
-  it("calls onLoadMore when visible window reaches near the end", async () => {
+  it("prepends new incoming rows without dropping existing rows", () => {
+    const initial = [makeRow(2), makeRow(3)];
+    const { rerender } = render(
+      <VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={initial} />
+    );
+
+    rerender(
+      <VirtualizedOrderBook
+        marketId={1}
+        outcomes={OUTCOMES}
+        initialRows={[makeRow(1), ...initial]}
+      />
+    );
+
+    expect(screen.getByTestId("order-row-1")).toBeInTheDocument();
+    expect(screen.getByTestId("order-row-2")).toBeInTheDocument();
+    expect(screen.getByTestId("order-row-3")).toBeInTheDocument();
+  });
+
+  // ── Load more button ──────────────────────────────────────────────────────
+
+  it("renders a load more button when more pages are available", () => {
+    render(
+      <VirtualizedOrderBook
+        marketId={1}
+        outcomes={OUTCOMES}
+        initialRows={Array.from({ length: 15 }, (_, i) => makeRow(i + 1))}
+        onLoadMore={jest.fn()}
+        hasMore
+      />
+    );
+
+    expect(screen.getByTestId("order-book-load-more")).toBeInTheDocument();
+  });
+
+  it("calls onLoadMore when the user clicks load more", async () => {
     const onLoadMore = jest.fn().mockResolvedValue([makeRow(21)]);
-    // 15 rows — mock renders all 15, visibleStopIndex=14, threshold=10 → 14 >= 15-10=5 → triggers
     const rows = Array.from({ length: 15 }, (_, i) => makeRow(i + 1));
 
+    render(
+      <VirtualizedOrderBook
+        marketId={1}
+        outcomes={OUTCOMES}
+        initialRows={rows}
+        onLoadMore={onLoadMore}
+        hasMore
+      />
+    );
+
     await act(async () => {
-      render(
-        <VirtualizedOrderBook
-          marketId={1}
-          outcomes={OUTCOMES}
-          initialRows={rows}
-          onLoadMore={onLoadMore}
-        />
-      );
+      fireEvent.click(screen.getByTestId("order-book-load-more"));
     });
 
     expect(onLoadMore).toHaveBeenCalledWith(2);
   });
 
-  it("does not call onLoadMore when list is short and not near end", async () => {
+  it("does not render the load more button when there are no more pages", () => {
     const onLoadMore = jest.fn().mockResolvedValue([]);
-    // 1 row — visibleStopIndex=0, threshold=10 → 0 >= 1-10=-9 → triggers
-    // Actually with 1 row it will trigger. Use 0 rows (empty state skips list entirely)
     render(
       <VirtualizedOrderBook
         marketId={1}
         outcomes={OUTCOMES}
-        initialRows={[]}
+        initialRows={[makeRow(1)]}
         onLoadMore={onLoadMore}
+        hasMore={false}
       />
     );
-    // Empty state renders no list, so onItemsRendered never fires
-    expect(onLoadMore).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("order-book-load-more")).not.toBeInTheDocument();
   });
 
   it("shows loading indicator while fetching more", async () => {
     let resolveLoad!: (rows: OrderBookRow[]) => void;
     const onLoadMore = jest.fn(
-      () => new Promise<OrderBookRow[]>((res) => { resolveLoad = res; })
+      () =>
+        new Promise<OrderBookRow[]>((res) => {
+          resolveLoad = res;
+        })
     );
     const rows = Array.from({ length: 15 }, (_, i) => makeRow(i + 1));
 
+    render(
+      <VirtualizedOrderBook
+        marketId={1}
+        outcomes={OUTCOMES}
+        initialRows={rows}
+        onLoadMore={onLoadMore}
+        hasMore
+      />
+    );
+
     await act(async () => {
-      render(
-        <VirtualizedOrderBook
-          marketId={1}
-          outcomes={OUTCOMES}
-          initialRows={rows}
-          onLoadMore={onLoadMore}
-        />
-      );
+      fireEvent.click(screen.getByTestId("order-book-load-more"));
     });
 
     expect(screen.getByTestId("order-book-loading")).toBeInTheDocument();
 
-    await act(async () => { resolveLoad([]); });
+    await act(async () => {
+      resolveLoad([]);
+    });
     expect(screen.queryByTestId("order-book-loading")).not.toBeInTheDocument();
   });
 
@@ -284,15 +274,18 @@ describe("VirtualizedOrderBook", () => {
     const onLoadMore = jest.fn().mockResolvedValue([newRow]);
     const rows = Array.from({ length: 15 }, (_, i) => makeRow(i + 1));
 
+    render(
+      <VirtualizedOrderBook
+        marketId={1}
+        outcomes={OUTCOMES}
+        initialRows={rows}
+        onLoadMore={onLoadMore}
+        hasMore
+      />
+    );
+
     await act(async () => {
-      render(
-        <VirtualizedOrderBook
-          marketId={1}
-          outcomes={OUTCOMES}
-          initialRows={rows}
-          onLoadMore={onLoadMore}
-        />
-      );
+      fireEvent.click(screen.getByTestId("order-book-load-more"));
     });
 
     // Row 100 should appear at least once after append
@@ -303,15 +296,18 @@ describe("VirtualizedOrderBook", () => {
     const onLoadMore = jest.fn().mockResolvedValue([]);
     const rows = Array.from({ length: 15 }, (_, i) => makeRow(i + 1));
 
+    render(
+      <VirtualizedOrderBook
+        marketId={1}
+        outcomes={OUTCOMES}
+        initialRows={rows}
+        onLoadMore={onLoadMore}
+        hasMore
+      />
+    );
+
     await act(async () => {
-      render(
-        <VirtualizedOrderBook
-          marketId={1}
-          outcomes={OUTCOMES}
-          initialRows={rows}
-          onLoadMore={onLoadMore}
-        />
-      );
+      fireEvent.click(screen.getByTestId("order-book-load-more"));
     });
 
     // Called once but returned empty — no new rows appended
@@ -322,11 +318,7 @@ describe("VirtualizedOrderBook", () => {
 
   it("renders column headers", () => {
     render(
-      <VirtualizedOrderBook
-        marketId={1}
-        outcomes={OUTCOMES}
-        initialRows={[makeRow(1)]}
-      />
+      <VirtualizedOrderBook marketId={1} outcomes={OUTCOMES} initialRows={[makeRow(1)]} hasMore />
     );
     expect(screen.getByText("Wallet")).toBeInTheDocument();
     expect(screen.getByText("Outcome")).toBeInTheDocument();

--- a/frontend/src/hooks/useOrderBook.ts
+++ b/frontend/src/hooks/useOrderBook.ts
@@ -20,24 +20,31 @@ const PAGE_SIZE = 50;
 export function useOrderBook(apiUrl: string, marketId: number) {
   const [rows, setRows] = useState<OrderBookRow[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
   const knownIds = useRef<Set<number>>(new Set());
 
-  async function fetchPage(page: number): Promise<OrderBookRow[]> {
+  async function fetchPage(page: number): Promise<{ rows: OrderBookRow[]; hasMore: boolean }> {
     const res = await fetch(
       `${apiUrl}/api/markets/${marketId}/bets?page=${page}&limit=${PAGE_SIZE}`
     );
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    return (data.bets ?? []) as OrderBookRow[];
+    return {
+      rows: (data.bets ?? []) as OrderBookRow[],
+      hasMore: Boolean(data.meta?.hasMore),
+    };
   }
 
   // Initial load + live polling for new rows
   useEffect(() => {
     let cancelled = false;
+    knownIds.current = new Set();
+    setRows([]);
+    setHasMore(true);
 
     async function poll() {
       try {
-        const fresh = await fetchPage(1);
+        const { rows: fresh, hasMore: nextHasMore } = await fetchPage(1);
         if (cancelled) return;
         const newRows = fresh.filter((r) => !knownIds.current.has(r.id));
         if (newRows.length > 0) {
@@ -45,6 +52,7 @@ export function useOrderBook(apiUrl: string, marketId: number) {
           // Prepend new rows so latest bets appear at the top
           setRows((prev) => [...newRows, ...prev]);
         }
+        setHasMore(nextHasMore);
         setError(null);
       } catch (err: any) {
         if (!cancelled) setError(err.message);
@@ -53,18 +61,25 @@ export function useOrderBook(apiUrl: string, marketId: number) {
 
     poll();
     const timer = setInterval(poll, POLL_MS);
-    return () => { cancelled = true; clearInterval(timer); };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiUrl, marketId]);
 
   /** Called by VirtualizedOrderBook's infinite scroll handler */
-  const loadMore = useCallback(async (page: number): Promise<OrderBookRow[]> => {
-    const pageRows = await fetchPage(page);
-    const newRows = pageRows.filter((r) => !knownIds.current.has(r.id));
-    newRows.forEach((r) => knownIds.current.add(r.id));
-    return newRows;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiUrl, marketId]);
+  const loadMore = useCallback(
+    async (page: number): Promise<OrderBookRow[]> => {
+      const { rows: pageRows, hasMore: nextHasMore } = await fetchPage(page);
+      setHasMore(nextHasMore);
+      const newRows = pageRows.filter((r) => !knownIds.current.has(r.id));
+      newRows.forEach((r) => knownIds.current.add(r.id));
+      return newRows;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    [apiUrl, marketId]
+  );
 
-  return { rows, error, loadMore };
+  return { rows, error, hasMore, loadMore };
 }


### PR DESCRIPTION
## Summary
This PR bundles four related platform hardening changes across the smart contract, backend, and frontend layers. The focus is operational safety, abuse resistance, and market-page performance.

Closes #397
Closes #399
Closes #464
Closes #467

## What Changed

### Smart Contract: Emergency Pause Module (#399)
- added a contract-wide emergency pause flag in instance storage
- initialize now seeds the pause state to false
- added `pause(env, caller)` gated to the `Pauser` role
- added `unpause(env, caller)` gated to the `Pauser` role
- added `is_paused(env)` getter for the contract-level pause state
- added a shared `require_not_paused` guard
- applied the pause guard to `place_bet`, `place_bet_with_sig`, and `claim_payout`
- added `ContractPaused` and `ContractUnpaused` event emission helpers and coverage

### Smart Contract: Configurable Minimum Bet Amount (#397)
- initialize now seeds `MinBetAmount` to `10_000_000` stroops (1 XLM)
- `place_bet` now enforces the configured minimum and panics with the required descriptive error message when violated
- added `set_min_bet(env, caller, new_min)` gated to the `FeeSetter` role
- `set_min_bet` validates the configured minimum and rejects values above 100 XLM
- added `MinBetUpdated` event emission on each successful minimum-bet update
- added tests covering the default minimum, FeeSetter-only updates, invalid upper bounds, and below-minimum bet rejection

### Backend: Request Body Size Limits (#464)
- replaced the implicit JSON body parser setup with explicit 10kb limits for JSON and URL-encoded bodies
- added a dedicated `413 Payload Too Large` handler with a stable, non-internal error message
- refactored backend app initialization so middleware and error handling can be exercised directly in tests
- documented the request body limit in the backend API docs
- added integration coverage proving that requests above 10kb are rejected and requests within the limit still succeed
- tightened the `GET /api/markets` pagination validation so decimal query strings are rejected as invalid integers

### Frontend: Virtualized Order Book (#467)
- completed the `VirtualizedOrderBook` flow around the existing component scaffold
- switched the UX to an explicit `Load more` action while preserving constant-DOM rendering through `react-window`
- kept the required fixed row height (`48px`) and viewport height (`400px`)
- implemented prepend-safe live updates so newly polled bets appear at the top without rebuilding the entire dataset
- added `hasMore` pagination support to the order-book hook
- added a backend `GET /api/markets/:id/bets` endpoint to support paginated market activity rows
- wired the order book into the market detail activity tab
- expanded frontend tests to cover row rendering, live prepends, loading state, and load-more pagination

## Files of Interest
- `contracts/prediction_market/src/lib.rs`
- `contracts/prediction_market/src/events.rs`
- `backend/src/index.js`
- `backend/src/routes/markets.js`
- `backend/src/tests/index.test.js`
- `frontend/src/components/VirtualizedOrderBook.tsx`
- `frontend/src/hooks/useOrderBook.ts`
- `frontend/src/app/market/[id]/MarketDetailPage.tsx`

## Verification
- `npm test -- --runTestsByPath src/tests/index.test.js src/tests/markets.test.js` in `backend/`
- `npm test -- --runTestsByPath src/components/__tests__/VirtualizedOrderBook.test.tsx` in `frontend/`
- `cargo build --manifest-path contracts/prediction_market/Cargo.toml`
- `~/.cargo/bin/cargo-audit audit -f contracts/prediction_market/Cargo.lock`

## Notes / Caveats
- `cargo-audit` runs successfully, but the current Soroban transitive dependency tree reports two upstream unmaintained warnings:
  - `RUSTSEC-2024-0388` (`derivative`)
  - `RUSTSEC-2024-0436` (`paste`)
- the full `contracts/prediction_market` test and clippy gates are already failing on unrelated pre-existing issues elsewhere in the crate, so contract verification for this PR is limited to a successful library build plus the targeted code review of the added logic
- generated frontend coverage artifacts were left out of the commit intentionally
