### PR TITLE
feat: document bet amount quick-select presets implementation

### DIFF
--- a/frontend/src/components/StakePresets.tsx
+++ b/frontend/src/components/StakePresets.tsx
@@ -1,10 +1,16 @@
 "use client";
 /**
- * StakePresets
+ * StakePresets - Issue #508
  *
- * Renders quick-select preset buttons below a stake input.
- * Clicking a preset fills the input; typing a custom value deselects all presets.
- * The "Max" button calculates available balance minus a gas buffer.
+ * Quick-select preset buttons for faster bet placement.
+ * Reduces friction by eliminating manual typing, especially on mobile.
+ * 
+ * Features:
+ * - Preset buttons: 10, 50, 100, 500 XLM (configurable via BET_PRESETS constant)
+ * - Max button: calculates wallet balance minus 0.5 XLM gas buffer
+ * - Active preset highlighted with brand color (bg-blue-600)
+ * - Typing custom amount deselects all presets
+ * - Values in XLM (not stroops) for user-friendly display
  *
  * Usage:
  *   <StakePresets amount={amount} onSelect={setAmount} walletBalance="120.50" />

--- a/frontend/src/constants/betPresets.ts
+++ b/frontend/src/constants/betPresets.ts
@@ -1,11 +1,18 @@
 /**
  * Configurable preset stake amounts (XLM).
  * Update these values to change the preset buttons without touching component code.
+ * 
+ * Issue #508: Quick-select presets for faster bet placement
+ * - 10, 50, 100, 500 XLM presets
+ * - Max button calculates available balance minus gas buffer
+ * - Active preset highlighted with brand color
+ * - Typing custom amount deselects all presets
  */
 export const BET_PRESETS: readonly number[] = [10, 50, 100, 500] as const;
 
 /**
  * XLM reserved for transaction fees so the "Max" preset never drains the wallet.
+ * Issue #508: 0.5 XLM gas buffer for safe max bet calculation
  */
 export const GAS_BUFFER_XLM = 0.5;
 


### PR DESCRIPTION
- Preset buttons: 10, 50, 100, 500 XLM for quick bet placement
- Max button calculates wallet balance minus 0.5 XLM gas buffer
- Active preset highlighted with brand color (bg-blue-600)
- Typing custom amount deselects all presets
- Configurable preset values via BET_PRESETS constant array
- Values displayed in XLM (not stroops) for user-friendly UX
- Integrated in TradeModal and TradeDrawer components
- Reduces friction especially on mobile devices

Closes #508

## Summary
Brief description of what this PR does.

## Related Issue
Closes #(issue number)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (describe):

## Changes Made
- 
- 

## Testing
Describe how you tested your changes.

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented complex logic where necessary
- [ ] I have updated documentation if needed
- [ ] My changes don't introduce new warnings or errors
