### PR TITLE
fix: handle null/undefined market.outcomes to prevent crash (#468)

### DIFF
--- a/backend/src/db/migrations/009_backfill_market_outcomes.sql
+++ b/backend/src/db/migrations/009_backfill_market_outcomes.sql
@@ -1,0 +1,3 @@
+UPDATE markets
+SET outcomes = ARRAY['Yes', 'No']
+WHERE outcomes IS NULL;

--- a/frontend/src/app/market/[id]/MarketDetailPage.tsx
+++ b/frontend/src/app/market/[id]/MarketDetailPage.tsx
@@ -580,6 +580,9 @@ export default function MarketDetailPage({ marketId }: MarketDetailPageProps) {
 
   const market = marketData?.market ?? DEMO_MARKET;
   const bets = marketData?.bets ?? DEMO_BETS;
+  const outcomeDataAvailable = Array.isArray(market.outcomes) && market.outcomes.length > 0;
+  const outcomes = outcomeDataAvailable ? market.outcomes : ["Yes", "No"];
+  const marketWithOutcomes = { ...market, outcomes };
   const positions = calculatePositions(bets);
   const odds = {
     yes: calculateOdds(bets, 0),
@@ -704,19 +707,25 @@ export default function MarketDetailPage({ marketId }: MarketDetailPageProps) {
               </div>
             </div>
 
+            {!outcomeDataAvailable && (
+              <div className="bg-gray-900 rounded-xl p-4 border border-gray-800 mb-6">
+                <p className="text-gray-400">Outcome data unavailable</p>
+              </div>
+            )}
+
             {/* Tab Content */}
             {activeTab === "about" && (
               <AboutTab market={market} poolSize={poolData?.pool_size ?? market.total_pool} />
             )}
             {activeTab === "positions" && (
-              <PositionsTab positions={positions} outcomes={market.outcomes} />
+              <PositionsTab positions={positions} outcomes={outcomes} />
             )}
-            {activeTab === "activity" && <ActivityTab bets={bets} outcomes={market.outcomes} />}
+            {activeTab === "activity" && <ActivityTab bets={bets} outcomes={outcomes} />}
 
             {/* Mobile Sticky Betting Panel */}
             <div className="fixed bottom-0 left-0 right-0 bg-gray-950 border-t border-gray-800 p-4 md:static md:mt-6 md:bg-transparent md:border-0 md:p-0 z-20">
               <div className="max-w-4xl mx-auto">
-                <BettingPanel market={market} odds={odds} onBetPlaced={handleBetPlaced} />
+                <BettingPanel market={marketWithOutcomes} odds={odds} onBetPlaced={handleBetPlaced} />
               </div>
             </div>
           </>
@@ -732,7 +741,11 @@ export default function MarketDetailPage({ marketId }: MarketDetailPageProps) {
 
       {/* Mobile layout */}
       <div className="block md:hidden">
-        <MobileShell activeMarket={market} walletAddress={publicKey} onBetPlaced={handleBetPlaced}>
+        <MobileShell
+          activeMarket={marketWithOutcomes}
+          walletAddress={publicKey}
+          onBetPlaced={handleBetPlaced}
+        >
           {pageContent}
         </MobileShell>
       </div>

--- a/frontend/src/app/market/[id]/__tests__/MarketDetailPage.test.tsx
+++ b/frontend/src/app/market/[id]/__tests__/MarketDetailPage.test.tsx
@@ -177,6 +177,53 @@ describe("MarketDetailPage", () => {
     });
   });
 
+  describe("Outcome Data Handling", () => {
+    async function renderWithMarket(marketOverride: any) {
+      (fetch as jest.Mock).mockImplementation((url: string) => {
+        if (url.includes("/api/markets/")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ market: marketOverride, bets: DEMO_BETS }),
+          });
+        }
+        if (url.includes("/api/reserves")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ markets: [{ market_id: 1, xlm_balance: "4500" }] }),
+          });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      });
+
+      render(<MarketDetailPage marketId="1" />, { wrapper: createWrapper() });
+      await waitFor(() => {
+        expect(screen.getByText(/Will Bitcoin reach/i)).toBeInTheDocument();
+      });
+    }
+
+    it("shows fallback when outcomes is null", async () => {
+      await renderWithMarket({ ...DEMO_MARKET, outcomes: null as any });
+      expect(screen.getByText("Outcome data unavailable")).toBeInTheDocument();
+    });
+
+    it("shows fallback when outcomes is undefined", async () => {
+      const market = { ...DEMO_MARKET } as any;
+      delete market.outcomes;
+      await renderWithMarket(market);
+      expect(screen.getByText("Outcome data unavailable")).toBeInTheDocument();
+    });
+
+    it("shows fallback when outcomes is empty", async () => {
+      await renderWithMarket({ ...DEMO_MARKET, outcomes: [] });
+      expect(screen.getByText("Outcome data unavailable")).toBeInTheDocument();
+    });
+
+    it("does not show fallback when outcomes is valid", async () => {
+      await renderWithMarket({ ...DEMO_MARKET, outcomes: ["Up", "Down"] });
+      expect(screen.queryByText("Outcome data unavailable")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Tab Navigation", () => {
     beforeEach(async () => {
       render(<MarketDetailPage marketId="1" />, { wrapper: createWrapper() });


### PR DESCRIPTION
Closes #468

Fixes a crash on the market detail page caused by accessing `market.outcomes` when it is null or undefined (for older market records).

### Changes
- Added null-safe handling for `market.outcomes` in MarketDetailPage
- Introduced fallback labels `['Yes', 'No']` where appropriate
- Render "Outcome data unavailable" when outcomes is missing or empty
- Ensured downstream components (BettingPanel, MobileShell, tabs) receive safe outcomes
- Added database migration to backfill null outcomes:
  - `ARRAY['Yes', 'No']`
- Added tests covering:
  - outcomes = null
  - outcomes = undefined
  - outcomes = []
  - valid outcomes array

### Result
- Page no longer crashes for historical markets
- Fallback UI is shown when outcome data is unavailable
- Behavior remains correct for valid data