### PR TITLE
fix: handle null outcomes crash

### DIFF
--- a/backend/src/db/migrations/010_backfill_null_outcomes.sql
+++ b/backend/src/db/migrations/010_backfill_null_outcomes.sql
@@ -1,0 +1,3 @@
+UPDATE markets
+SET outcomes = ARRAY['Yes', 'No']
+WHERE outcomes IS NULL;

--- a/frontend/src/app/market/[id]/MarketDetailPage.tsx
+++ b/frontend/src/app/market/[id]/MarketDetailPage.tsx
@@ -569,6 +569,12 @@ export default function MarketDetailPage({ marketId }: MarketDetailPageProps) {
     yes: calculateOdds(bets, 0),
     no: calculateOdds(bets, 1),
   };
+  const outcomes =
+    Array.isArray(market.outcomes) && market.outcomes.length > 0
+      ? market.outcomes
+      : ["Yes", "No"];
+  const outcomeDataAvailable =
+    Array.isArray(market.outcomes) && market.outcomes.length > 0;
 
   function handleBetPlaced() {}
 
@@ -689,14 +695,17 @@ export default function MarketDetailPage({ marketId }: MarketDetailPageProps) {
             </div>
 
             {/* Tab Content */}
+            {!outcomeDataAvailable && (
+              <p className="text-gray-500 text-xs mb-4">Outcome data unavailable</p>
+            )}
             {activeTab === "about" && (
               <AboutTab market={market} poolSize={poolData?.pool_size ?? market.total_pool} />
             )}
             {activeTab === "positions" && (
-              <PositionsTab positions={positions} outcomes={market.outcomes} />
+              <PositionsTab positions={positions} outcomes={outcomes} />
             )}
             {activeTab === "activity" && (
-              <ActivityTab marketId={market.id} outcomes={market.outcomes} />
+              <ActivityTab marketId={market.id} outcomes={outcomes} />
             )}
 
             {/* Mobile Sticky Betting Panel */}

--- a/frontend/src/app/market/[id]/__tests__/MarketDetailPage.test.tsx
+++ b/frontend/src/app/market/[id]/__tests__/MarketDetailPage.test.tsx
@@ -177,6 +177,53 @@ describe("MarketDetailPage", () => {
     });
   });
 
+  describe("Outcome Data Handling", () => {
+    async function renderWithMarket(marketOverride: any) {
+      (fetch as jest.Mock).mockImplementation((url: string) => {
+        if (url.includes("/api/markets/")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ market: marketOverride, bets: DEMO_BETS }),
+          });
+        }
+        if (url.includes("/api/reserves")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ markets: [{ market_id: 1, xlm_balance: "4500" }] }),
+          });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      });
+
+      render(<MarketDetailPage marketId="1" />, { wrapper: createWrapper() });
+      await waitFor(() => {
+        expect(screen.getByText(/Will Bitcoin reach/i)).toBeInTheDocument();
+      });
+    }
+
+    it("shows fallback when outcomes is null", async () => {
+      await renderWithMarket({ ...DEMO_MARKET, outcomes: null as any });
+      expect(screen.getByText("Outcome data unavailable")).toBeInTheDocument();
+    });
+
+    it("shows fallback when outcomes is undefined", async () => {
+      const market = { ...DEMO_MARKET } as any;
+      delete market.outcomes;
+      await renderWithMarket(market);
+      expect(screen.getByText("Outcome data unavailable")).toBeInTheDocument();
+    });
+
+    it("shows fallback when outcomes is empty", async () => {
+      await renderWithMarket({ ...DEMO_MARKET, outcomes: [] });
+      expect(screen.getByText("Outcome data unavailable")).toBeInTheDocument();
+    });
+
+    it("does not show fallback when outcomes is valid", async () => {
+      await renderWithMarket({ ...DEMO_MARKET, outcomes: ["Up", "Down"] });
+      expect(screen.queryByText("Outcome data unavailable")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Tab Navigation", () => {
     beforeEach(async () => {
       render(<MarketDetailPage marketId="1" />, { wrapper: createWrapper() });


### PR DESCRIPTION
Closes #491

---

Closes Hahfyeex/Stellar-PolyMarket#468

Fixes a crash on the market detail page caused by accessing `market.outcomes` when it is null, undefined, or empty.

### Changes
- added null-safe handling for `market.outcomes`
- fallback to ['Yes', 'No'] when missing
- render "Outcome data unavailable" when data is missing
- added migration to backfill null outcomes
- added tests for null, undefined, empty, and valid cases

### Notes
- tests could not run locally due to environment restrictions (PowerShell/npm/jest)