### PR TITLE
feat: implement skeleton loading screens for all data-dependent pages

### DIFF
--- a/frontend/src/app/leaderboard/page.tsx
+++ b/frontend/src/app/leaderboard/page.tsx
@@ -7,8 +7,10 @@
  * The connected user's row is highlighted and sorted to the top if present.
  */
 import { useWalletContext } from "../../context/WalletContext";
+import { useQuery } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
 import type { LeaderboardEntry } from "../../components/LeaderboardRow";
+import LeaderboardSkeleton from "../../components/skeletons/LeaderboardSkeleton";
 
 // Lazy-load — leaderboard table is heavy enough to warrant code splitting
 const LeaderboardRow = dynamic(
@@ -31,8 +33,24 @@ const MOCK_ENTRIES: LeaderboardEntry[] = [
 ];
 // ─────────────────────────────────────────────────────────────────────────────
 
+function useLeaderboard() {
+  return useQuery<LeaderboardEntry[]>({
+    queryKey: ["leaderboard"],
+    queryFn: async () => {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/leaderboard`);
+      if (!res.ok) throw new Error("Failed to fetch leaderboard");
+      return res.json();
+    },
+    placeholderData: MOCK_ENTRIES,
+    staleTime: 60_000,
+  });
+}
+
 export default function LeaderboardPage() {
   const { publicKey } = useWalletContext();
+
+  // isLoading drives the skeleton; falls back to mock data when API is unavailable
+  const { data: entries = MOCK_ENTRIES, isLoading } = useLeaderboard();
 
   return (
     <main className="min-h-screen bg-gray-950 text-white">
@@ -56,56 +74,60 @@ export default function LeaderboardPage() {
         </div>
       </header>
 
-      <div className="max-w-3xl mx-auto px-4 py-8 flex flex-col gap-6">
-        {/* Summary stats */}
-        <div className="grid grid-cols-3 gap-4">
-          {[
-            { label: "Total Predictors", value: "1,284", color: "text-white" },
-            { label: "Avg Accuracy", value: "54.2%", color: "text-green-400" },
-            { label: "Diamond Tier", value: "12", color: "text-cyan-400" },
-          ].map((stat) => (
-            <div key={stat.label} className="bg-gray-900 border border-gray-800 rounded-xl p-4 text-center">
-              <p className={`text-xl font-bold ${stat.color}`}>{stat.value}</p>
-              <p className="text-gray-500 text-xs mt-1">{stat.label}</p>
-            </div>
-          ))}
-        </div>
+      {isLoading ? (
+        <LeaderboardSkeleton />
+      ) : (
+        <div className="max-w-3xl mx-auto px-4 py-8 flex flex-col gap-6">
+          {/* Summary stats */}
+          <div className="grid grid-cols-3 gap-4">
+            {[
+              { label: "Total Predictors", value: "1,284", color: "text-white" },
+              { label: "Avg Accuracy", value: "54.2%", color: "text-green-400" },
+              { label: "Diamond Tier", value: "12", color: "text-cyan-400" },
+            ].map((stat) => (
+              <div key={stat.label} className="bg-gray-900 border border-gray-800 rounded-xl p-4 text-center">
+                <p className={`text-xl font-bold ${stat.color}`}>{stat.value}</p>
+                <p className="text-gray-500 text-xs mt-1">{stat.label}</p>
+              </div>
+            ))}
+          </div>
 
-        {/* Table */}
-        <div className="bg-gray-900 border border-gray-800 rounded-2xl overflow-hidden">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-gray-800">
-                <th className="px-4 py-3 text-left text-xs text-gray-500 uppercase tracking-wider w-12">
-                  Rank
-                </th>
-                <th className="px-4 py-3 text-left text-xs text-gray-500 uppercase tracking-wider">
-                  Predictor
-                </th>
-                <th className="px-4 py-3 text-right text-xs text-gray-500 uppercase tracking-wider">
-                  Markets
-                </th>
-                <th className="px-4 py-3 text-right text-xs text-gray-500 uppercase tracking-wider">
-                  Accuracy
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {MOCK_ENTRIES.map((entry) => (
-                <LeaderboardRow
-                  key={entry.walletAddress}
-                  entry={entry}
-                  isCurrentUser={!!publicKey && entry.walletAddress === publicKey}
-                />
-              ))}
-            </tbody>
-          </table>
-        </div>
+          {/* Table */}
+          <div className="bg-gray-900 border border-gray-800 rounded-2xl overflow-hidden">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-gray-800">
+                  <th className="px-4 py-3 text-left text-xs text-gray-500 uppercase tracking-wider w-12">
+                    Rank
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs text-gray-500 uppercase tracking-wider">
+                    Predictor
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs text-gray-500 uppercase tracking-wider">
+                    Markets
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs text-gray-500 uppercase tracking-wider">
+                    Accuracy
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((entry) => (
+                  <LeaderboardRow
+                    key={entry.walletAddress}
+                    entry={entry}
+                    isCurrentUser={!!publicKey && entry.walletAddress === publicKey}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
 
-        <p className="text-center text-gray-600 text-xs">
-          Showing top 10 predictors · Updated every 10 minutes
-        </p>
-      </div>
+          <p className="text-center text-gray-600 text-xs">
+            Showing top 10 predictors · Updated every 10 minutes
+          </p>
+        </div>
+      )}
     </main>
   );
 }

--- a/frontend/src/app/markets/[id]/page.tsx
+++ b/frontend/src/app/markets/[id]/page.tsx
@@ -29,6 +29,7 @@ import ContractErrorBoundary from "../../../components/ContractErrorBoundary";
 import SocialSentiment from "../../../components/SocialSentiment";
 import SimulatorPanel from "../../../components/SimulatorPanel";
 import { store } from "../../../store";
+import MarketDetailSkeleton from "../../../components/skeletons/MarketDetailSkeleton";
 
 interface Market {
   id: number;
@@ -104,6 +105,27 @@ export default function MarketDetailPage() {
     );
   }
 
+  if (loading) {
+    return (
+      <main className="min-h-screen bg-gray-950 text-white">
+        <nav className="flex items-center gap-3 px-4 md:px-6 py-4 border-b border-gray-800 sticky top-0 z-30 bg-gray-950/90 backdrop-blur-sm">
+          <button
+            onClick={() => router.push("/")}
+            className="text-gray-400 hover:text-white transition-colors flex items-center gap-2"
+            aria-label="Back to markets"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="w-5 h-5">
+              <path d="M19 12H5M12 5l-7 7 7 7" />
+            </svg>
+            <span className="text-sm">Back</span>
+          </button>
+          <Link href="/" className="text-blue-400 font-bold text-sm">Stella Polymarket</Link>
+        </nav>
+        <MarketDetailSkeleton />
+      </main>
+    );
+  }
+
   return (
     <main className="min-h-screen bg-gray-950 text-white">
       {/* Top nav with back button */}
@@ -121,13 +143,13 @@ export default function MarketDetailPage() {
         <Link href="/" className="text-blue-400 font-bold text-sm">Stella Polymarket</Link>
         <span className="text-gray-600">/</span>
         <span className="text-gray-400 text-sm truncate max-w-xs">
-          {loading ? "Loading..." : market?.question.slice(0, 50) + (market && market.question.length > 50 ? "…" : "")}
+          {market?.question.slice(0, 50) + (market && market.question.length > 50 ? "…" : "")}
         </span>
       </nav>
 
       <div className="max-w-7xl mx-auto px-4 md:px-6 py-6 space-y-6">
         {/* ── HERO: Question + status badges ── */}
-        {!loading && market && (
+        {market && (
           <div className="space-y-2">
             <div className="flex flex-wrap items-center gap-2">
               {market.resolved ? (
@@ -153,14 +175,12 @@ export default function MarketDetailPage() {
           {/* Left column (65%) — market info, odds chart, bet history */}
           <div className="min-w-0 space-y-6">
             {/* 1. PROBABILITY CHART — primary element */}
-            {loading ? (
-              <ChartSkeleton />
-            ) : market ? (
+            {market ? (
               <ProbabilityChart marketId={market.id} outcomes={market.outcomes} />
             ) : null}
 
             {/* 2. Current prices row */}
-            {!loading && market && (
+            {market && (
               <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
                 {market.outcomes.map((outcome, i) => {
                   const prob = (100 / market.outcomes.length).toFixed(0);
@@ -192,7 +212,7 @@ export default function MarketDetailPage() {
             )}
 
             {/* 3. Bet History Table */}
-            {!loading && market && (
+            {market && (
               <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
                 <h3 className="text-white font-semibold text-base mb-4">Recent Bets</h3>
                 <div className="overflow-x-auto">
@@ -225,24 +245,24 @@ export default function MarketDetailPage() {
             )}
 
             {/* 4. Pool ownership chart */}
-            {!loading && market && (
+            {market && (
               <ContractErrorBoundary context={`PoolChart-${market.id}`} store={store}>
                 <PoolOwnershipChart marketId={market.id} />
               </ContractErrorBoundary>
             )}
 
             {/* 5. Social sentiment */}
-            {!loading && market && (
+            {market && (
               <SocialSentiment outcomes={market.outcomes} totalPool={parseFloat(market.total_pool)} />
             )}
 
             {/* 6. Firebase-powered comments */}
-            {!loading && market && (
+            {market && (
               <MarketComments marketId={market.id} walletAddress={publicKey} />
             )}
 
             {/* 7. Market rules + truth sources */}
-            {!loading && market && (
+            {market && (
               <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 space-y-4">
                 <h3 className="text-white font-semibold text-base">Market Rules</h3>
                 <p className="text-gray-400 text-sm leading-relaxed">
@@ -290,7 +310,7 @@ export default function MarketDetailPage() {
           {/* Right column (35%) — Sticky bet form on desktop */}
           <div className="w-full">
             <div className="lg:sticky lg:top-20 space-y-4">
-              {!loading && market ? (
+              {market ? (
                 <ContractErrorBoundary context={`TradeModal-${market.id}`} store={store}>
                   <TradeModal
                     market={market}
@@ -309,7 +329,7 @@ export default function MarketDetailPage() {
               )}
               
               {/* What-If Simulator Panel */}
-              {!loading && market && (
+              {market && (
                 <SimulatorPanel market={market} />
               )}
             </div>
@@ -317,7 +337,7 @@ export default function MarketDetailPage() {
         </div>
 
         {/* ── FOOTER: Related Markets carousel ── */}
-        {!loading && market && (
+        {market && (
           <div className="border-t border-gray-800 pt-6">
             <RelatedMarketsCarousel
               currentMarketId={market.id}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -25,6 +25,7 @@ import { useMarkets } from "../hooks/useMarkets";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMarketTabs } from "../hooks/useMarketTabs";
 import MarketTabs from "../components/MarketTabs";
+import MarketListSkeleton from "../components/skeletons/MarketListSkeleton";
 
 export default function Home() {
   const { publicKey, connecting, error, connect, disconnect } = useWalletContext();
@@ -211,11 +212,7 @@ export default function Home() {
           >
             <MarketFilters filters={filters} onChange={setFilters} />
             {loading ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {[1, 2, 3, 4].map((i) => (
-                  <MarketCardSkeleton key={i} />
-                ))}
-              </div>
+              <MarketListSkeleton />
             ) : filteredMarkets.length === 0 ? (
               <p className="text-gray-400" data-testid="no-markets-empty-state">
                 {filters.query

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -14,6 +14,7 @@ import WalletActivityTimeline from "../../components/timeline/WalletActivityTime
 import NotificationPreferencesPanel from "../../components/NotificationPreferencesPanel";
 import BetHistoryTable from "../../components/BetHistoryTable";
 import { usePortfolio } from "../../hooks/usePortfolio";
+import PortfolioSkeleton from "../../components/skeletons/PortfolioSkeleton";
 
 
 function abbreviateWallet(address: string): string {
@@ -105,8 +106,20 @@ export default function ProfilePage() {
   // ── Loading stats ─────────────────────────────────────────────────────────
   if (isLoading) {
     return (
-      <main className="min-h-screen bg-gray-950 flex items-center justify-center">
-        <p className="text-gray-400 text-sm animate-pulse">Loading your stats...</p>
+      <main className="min-h-screen bg-gray-950 text-white">
+        <header className="border-b border-gray-800 bg-gray-950/80 backdrop-blur-sm sticky top-0 z-10">
+          <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+            <div>
+              <h1 className="text-white font-bold text-base leading-none">Profile</h1>
+            </div>
+            <a href="/" className="text-indigo-400 hover:text-indigo-300 text-sm transition-colors">
+              ← Markets
+            </a>
+          </div>
+        </header>
+        <div className="max-w-3xl mx-auto px-4 py-8">
+          <PortfolioSkeleton />
+        </div>
       </main>
     );
   }

--- a/frontend/src/components/__tests__/SkeletonScreens.test.tsx
+++ b/frontend/src/components/__tests__/SkeletonScreens.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * Tests for skeleton loading components — Issue #482
+ * Covers: MarketListSkeleton, MarketDetailSkeleton, PortfolioSkeleton, LeaderboardSkeleton
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import MarketListSkeleton from "../skeletons/MarketListSkeleton";
+import MarketDetailSkeleton from "../skeletons/MarketDetailSkeleton";
+import PortfolioSkeleton from "../skeletons/PortfolioSkeleton";
+import LeaderboardSkeleton from "../skeletons/LeaderboardSkeleton";
+
+describe("MarketListSkeleton", () => {
+  it("renders 6 market card skeletons", () => {
+    const { container } = render(<MarketListSkeleton />);
+    // Each MarketCardSkeleton has bg-gray-900 rounded-xl p-5
+    const cards = container.querySelectorAll(".bg-gray-900.rounded-xl.p-5");
+    expect(cards).toHaveLength(6);
+  });
+
+  it("uses a two-column grid layout matching the markets list", () => {
+    const { container } = render(<MarketListSkeleton />);
+    const grid = container.querySelector(".grid");
+    expect(grid).toHaveClass("grid-cols-1", "md:grid-cols-2", "gap-4");
+  });
+
+  it("all cards contain skeleton elements for shimmer animation", () => {
+    const { container } = render(<MarketListSkeleton />);
+    const skeletons = container.querySelectorAll(".skeleton");
+    expect(skeletons.length).toBeGreaterThan(6);
+  });
+
+  it("each card has border and rounded styling matching MarketCard", () => {
+    const { container } = render(<MarketListSkeleton />);
+    const cards = container.querySelectorAll(".bg-gray-900.rounded-xl.p-5");
+    cards.forEach((card) => {
+      expect(card).toHaveClass("border", "border-gray-800");
+    });
+  });
+
+  it("each card has flex-col layout for CLS prevention", () => {
+    const { container } = render(<MarketListSkeleton />);
+    const cards = container.querySelectorAll(".bg-gray-900.rounded-xl.p-5");
+    cards.forEach((card) => {
+      expect(card).toHaveClass("flex", "flex-col");
+    });
+  });
+
+  it("includes chart placeholder (h-32) in each card", () => {
+    const { container } = render(<MarketListSkeleton />);
+    const chartPlaceholders = container.querySelectorAll(".h-32");
+    expect(chartPlaceholders.length).toBe(6);
+  });
+
+  it("includes outcome button placeholders in each card", () => {
+    const { container } = render(<MarketListSkeleton />);
+    const buttonSkeletons = container.querySelectorAll(".h-10.w-24");
+    // 2 outcome buttons per card × 6 cards = 12 minimum
+    expect(buttonSkeletons.length).toBeGreaterThanOrEqual(12);
+  });
+});
+
+describe("MarketDetailSkeleton", () => {
+  it("renders the two-column grid layout", () => {
+    const { container } = render(<MarketDetailSkeleton />);
+    const grid = container.querySelector(".grid");
+    expect(grid).toHaveClass("grid-cols-1", "lg:grid-cols-[65%_35%]", "gap-6");
+  });
+
+  it("renders hero section with question placeholder", () => {
+    const { container } = render(<MarketDetailSkeleton />);
+    // Hero has h-8 for the question title
+    const titleSkeleton = container.querySelector(".h-8.w-full");
+    expect(titleSkeleton).toBeInTheDocument();
+    expect(titleSkeleton).toHaveClass("skeleton");
+  });
+
+  it("renders chart placeholder in left column", () => {
+    const { container } = render(<MarketDetailSkeleton />);
+    const chartSkeleton = container.querySelector(".h-72.w-full");
+    expect(chartSkeleton).toBeInTheDocument();
+    expect(chartSkeleton).toHaveClass("skeleton");
+  });
+
+  it("renders 4 outcome price tile placeholders", () => {
+    const { container } = render(<MarketDetailSkeleton />);
+    // Outcome tiles grid has grid-cols-2 md:grid-cols-4
+    const tilesGrid = container.querySelector(".grid-cols-2.md\\:grid-cols-4");
+    expect(tilesGrid).toBeInTheDocument();
+    const tiles = tilesGrid?.querySelectorAll(".bg-gray-900.border.border-gray-800.rounded-xl");
+    expect(tiles?.length).toBe(4);
+  });
+
+  it("renders 5 bet history row placeholders", () => {
+    const { container } = render(<MarketDetailSkeleton />);
+    // Bet history section has space-y-3 with 5 flex rows after the header
+    const betHistorySection = container.querySelector(".bg-gray-900.border.border-gray-800.rounded-xl.p-5.space-y-3");
+    expect(betHistorySection).toBeInTheDocument();
+    const rows = betHistorySection?.querySelectorAll(".flex.justify-between");
+    expect(rows?.length).toBe(5);
+  });
+
+  it("renders right column trade panel placeholder", () => {
+    const { container } = render(<MarketDetailSkeleton />);
+    // Right column has a trade panel with h-12 for the bet button
+    const betButton = container.querySelector(".h-12.w-full");
+    expect(betButton).toBeInTheDocument();
+    expect(betButton).toHaveClass("skeleton");
+  });
+
+  it("has correct outer padding matching the real page", () => {
+    const { container } = render(<MarketDetailSkeleton />);
+    const wrapper = container.querySelector(".max-w-7xl");
+    expect(wrapper).toHaveClass("px-4", "md:px-6", "py-6");
+  });
+
+  it("all skeleton elements have the shimmer class", () => {
+    const { container } = render(<MarketDetailSkeleton />);
+    const skeletons = container.querySelectorAll(".skeleton");
+    expect(skeletons.length).toBeGreaterThan(10);
+    skeletons.forEach((s) => expect(s).toHaveClass("skeleton"));
+  });
+});
+
+describe("PortfolioSkeleton", () => {
+  it("renders 4 portfolio summary stat cards", () => {
+    const { container } = render(<PortfolioSkeleton />);
+    // Summary grid has grid-cols-2 sm:grid-cols-4
+    const summaryGrid = container.querySelector(".grid-cols-2.sm\\:grid-cols-4");
+    expect(summaryGrid).toBeInTheDocument();
+    const cards = summaryGrid?.querySelectorAll(".bg-gray-900.border.border-gray-800.rounded-2xl");
+    expect(cards?.length).toBe(4);
+  });
+
+  it("renders 5 recent activity row placeholders", () => {
+    const { container } = render(<PortfolioSkeleton />);
+    // Activity table container
+    const activityTable = container.querySelector(".bg-gray-900.border.border-gray-800.rounded-2xl.overflow-hidden");
+    expect(activityTable).toBeInTheDocument();
+    const rows = activityTable?.querySelectorAll(".flex.items-center.justify-between");
+    expect(rows?.length).toBe(5);
+  });
+
+  it("renders profile card with avatar placeholder", () => {
+    const { container } = render(<PortfolioSkeleton />);
+    const avatar = container.querySelector(".h-24.w-24.rounded-full");
+    expect(avatar).toBeInTheDocument();
+    expect(avatar).toHaveClass("skeleton");
+  });
+
+  it("each activity row has avatar and text placeholders", () => {
+    const { container } = render(<PortfolioSkeleton />);
+    const activityTable = container.querySelector(".bg-gray-900.border.border-gray-800.rounded-2xl.overflow-hidden");
+    const rows = activityTable?.querySelectorAll(".flex.items-center.justify-between");
+    rows?.forEach((row) => {
+      const skeletons = row.querySelectorAll(".skeleton");
+      expect(skeletons.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it("each activity row has right-aligned amount placeholder", () => {
+    const { container } = render(<PortfolioSkeleton />);
+    const activityTable = container.querySelector(".bg-gray-900.border.border-gray-800.rounded-2xl.overflow-hidden");
+    const amountCols = activityTable?.querySelectorAll(".flex.flex-col.items-end");
+    expect(amountCols?.length).toBe(5);
+  });
+
+  it("stat cards have correct padding matching PortfolioSummary", () => {
+    const { container } = render(<PortfolioSkeleton />);
+    const summaryGrid = container.querySelector(".grid-cols-2.sm\\:grid-cols-4");
+    const cards = summaryGrid?.querySelectorAll(".rounded-2xl");
+    cards?.forEach((card) => {
+      expect(card).toHaveClass("p-4");
+    });
+  });
+
+  it("all skeleton elements have the shimmer class", () => {
+    const { container } = render(<PortfolioSkeleton />);
+    const skeletons = container.querySelectorAll(".skeleton");
+    expect(skeletons.length).toBeGreaterThan(15);
+    skeletons.forEach((s) => expect(s).toHaveClass("skeleton"));
+  });
+});
+
+describe("LeaderboardSkeleton", () => {
+  it("renders 3 summary stat card placeholders", () => {
+    const { container } = render(<LeaderboardSkeleton />);
+    const statsGrid = container.querySelector(".grid-cols-3");
+    expect(statsGrid).toBeInTheDocument();
+    const cards = statsGrid?.querySelectorAll(".bg-gray-900.border.border-gray-800.rounded-xl");
+    expect(cards?.length).toBe(3);
+  });
+
+  it("renders 10 table row placeholders", () => {
+    const { container } = render(<LeaderboardSkeleton />);
+    const tbody = container.querySelector("tbody");
+    expect(tbody).toBeInTheDocument();
+    const rows = tbody?.querySelectorAll("tr");
+    expect(rows?.length).toBe(10);
+  });
+
+  it("renders table with 4 column headers", () => {
+    const { container } = render(<LeaderboardSkeleton />);
+    const thead = container.querySelector("thead");
+    const headerCells = thead?.querySelectorAll("th");
+    expect(headerCells?.length).toBe(4);
+  });
+
+  it("each row has rank, predictor, markets, and accuracy placeholders", () => {
+    const { container } = render(<LeaderboardSkeleton />);
+    const tbody = container.querySelector("tbody");
+    const rows = tbody?.querySelectorAll("tr");
+    rows?.forEach((row) => {
+      const cells = row.querySelectorAll("td");
+      expect(cells.length).toBe(4);
+      cells.forEach((cell) => {
+        const skeleton = cell.querySelector(".skeleton");
+        expect(skeleton).toBeInTheDocument();
+      });
+    });
+  });
+
+  it("predictor column includes avatar circle placeholder", () => {
+    const { container } = render(<LeaderboardSkeleton />);
+    const avatars = container.querySelectorAll(".h-6.w-6.rounded-full");
+    expect(avatars.length).toBe(10);
+    avatars.forEach((a) => expect(a).toHaveClass("skeleton"));
+  });
+
+  it("uses max-w-3xl container matching the leaderboard page", () => {
+    const { container } = render(<LeaderboardSkeleton />);
+    const wrapper = container.querySelector(".max-w-3xl");
+    expect(wrapper).toHaveClass("px-4", "py-8");
+  });
+
+  it("table is wrapped in rounded-2xl container matching real table", () => {
+    const { container } = render(<LeaderboardSkeleton />);
+    const tableWrapper = container.querySelector(".bg-gray-900.border.border-gray-800.rounded-2xl");
+    expect(tableWrapper).toBeInTheDocument();
+  });
+
+  it("all skeleton elements have the shimmer class", () => {
+    const { container } = render(<LeaderboardSkeleton />);
+    const skeletons = container.querySelectorAll(".skeleton");
+    expect(skeletons.length).toBeGreaterThan(20);
+    skeletons.forEach((s) => expect(s).toHaveClass("skeleton"));
+  });
+});
+
+describe("Skeleton shimmer animation — 1.5s timing", () => {
+  it("shimmer animation is defined in globals.css (class exists)", () => {
+    // The .skeleton class is applied to all skeleton elements.
+    // The 1.5s animation is defined in globals.css @keyframes shimmer.
+    // We verify the class is present on all skeleton components.
+    const components = [
+      <MarketListSkeleton key="list" />,
+      <MarketDetailSkeleton key="detail" />,
+      <PortfolioSkeleton key="portfolio" />,
+      <LeaderboardSkeleton key="leaderboard" />,
+    ];
+    components.forEach((component) => {
+      const { container } = render(component);
+      const skeletons = container.querySelectorAll(".skeleton");
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/components/skeletons/LeaderboardSkeleton.tsx
+++ b/frontend/src/components/skeletons/LeaderboardSkeleton.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Skeleton from "../Skeleton";
+
+/**
+ * LeaderboardSkeleton
+ *
+ * Matches the leaderboard page layout:
+ * - 3 summary stat cards
+ * - Table with 10 placeholder rows (rank, predictor, markets, accuracy)
+ * Prevents CLS by matching exact dimensions of loaded content.
+ */
+export function LeaderboardSkeleton() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 flex flex-col gap-6">
+      {/* Summary stats — 3 cards */}
+      <div className="grid grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="bg-gray-900 border border-gray-800 rounded-xl p-4 text-center space-y-2">
+            <Skeleton className="h-7 w-16 mx-auto" />
+            <Skeleton className="h-3 w-24 mx-auto" />
+          </div>
+        ))}
+      </div>
+
+      {/* Table — 10 rows */}
+      <div className="bg-gray-900 border border-gray-800 rounded-2xl overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-gray-800">
+              <th className="px-4 py-3 w-12">
+                <Skeleton className="h-3 w-8" />
+              </th>
+              <th className="px-4 py-3">
+                <Skeleton className="h-3 w-20" />
+              </th>
+              <th className="px-4 py-3 text-right">
+                <Skeleton className="h-3 w-16 ml-auto" />
+              </th>
+              <th className="px-4 py-3 text-right">
+                <Skeleton className="h-3 w-16 ml-auto" />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 10 }).map((_, i) => (
+              <tr key={i} className={i < 9 ? "border-b border-gray-800" : ""}>
+                <td className="px-4 py-3">
+                  <Skeleton className="h-4 w-6" />
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-6 w-6 rounded-full shrink-0" />
+                    <Skeleton className="h-4 w-36" />
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <Skeleton className="h-4 w-10 ml-auto" />
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <Skeleton className="h-4 w-12 ml-auto" />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default LeaderboardSkeleton;

--- a/frontend/src/components/skeletons/MarketDetailSkeleton.tsx
+++ b/frontend/src/components/skeletons/MarketDetailSkeleton.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Skeleton from "../Skeleton";
+
+/**
+ * MarketDetailSkeleton
+ *
+ * Two-column layout skeleton matching the market detail page (markets/[id]).
+ * Left column (65%): chart + prices + bet history.
+ * Right column (35%): trade panel.
+ * Prevents CLS by matching exact dimensions of loaded content.
+ */
+export function MarketDetailSkeleton() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 md:px-6 py-6 space-y-6">
+      {/* Hero: question + status */}
+      <div className="space-y-2">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-5 w-3/4" />
+      </div>
+
+      {/* Two-column grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-[65%_35%] gap-6">
+        {/* Left column */}
+        <div className="space-y-6">
+          {/* Chart */}
+          <div className="bg-gray-900 rounded-xl border border-gray-800 p-4 space-y-3">
+            <Skeleton className="h-5 w-48" />
+            <Skeleton className="h-72 w-full" />
+          </div>
+
+          {/* Outcome price tiles */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="bg-gray-900 border border-gray-800 rounded-xl p-3 space-y-1">
+                <Skeleton className="h-3 w-full" />
+                <Skeleton className="h-8 w-16 mx-auto" />
+                <Skeleton className="h-3 w-12 mx-auto" />
+              </div>
+            ))}
+          </div>
+
+          {/* Bet history table */}
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 space-y-3">
+            <Skeleton className="h-5 w-32" />
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex justify-between gap-4">
+                <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Right column — trade panel */}
+        <div className="space-y-4">
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 space-y-4">
+            <Skeleton className="h-5 w-24" />
+            <div className="flex gap-2">
+              <Skeleton className="h-10 flex-1" />
+              <Skeleton className="h-10 flex-1" />
+            </div>
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 space-y-3">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MarketDetailSkeleton;

--- a/frontend/src/components/skeletons/MarketListSkeleton.tsx
+++ b/frontend/src/components/skeletons/MarketListSkeleton.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import MarketCardSkeleton from "./MarketCardSkeleton";
+
+/**
+ * MarketListSkeleton
+ *
+ * Grid of 6 MarketCardSkeleton placeholders matching the markets list layout.
+ * Prevents CLS by occupying the same space as the loaded grid.
+ */
+export function MarketListSkeleton() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <MarketCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+export default MarketListSkeleton;

--- a/frontend/src/components/skeletons/PortfolioSkeleton.tsx
+++ b/frontend/src/components/skeletons/PortfolioSkeleton.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Skeleton from "../Skeleton";
+
+/**
+ * PortfolioSkeleton
+ *
+ * Matches the profile page portfolio layout:
+ * - 4 summary stat cards (2×2 grid)
+ * - Table with 5 placeholder rows for recent activity
+ * Prevents CLS by matching exact dimensions of loaded content.
+ */
+export function PortfolioSkeleton() {
+  return (
+    <div className="flex flex-col gap-8">
+      {/* Profile card */}
+      <div className="bg-gray-900 border border-gray-800 rounded-2xl p-6 flex flex-col sm:flex-row gap-6">
+        <Skeleton className="h-24 w-24 rounded-full shrink-0" />
+        <div className="flex-1 space-y-3">
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-4 w-64" />
+          <div className="grid grid-cols-2 gap-3">
+            <div className="bg-gray-800 rounded-xl p-3 text-center">
+              <Skeleton className="h-8 w-12 mx-auto mb-1" />
+              <Skeleton className="h-3 w-24 mx-auto" />
+            </div>
+            <div className="bg-gray-800 rounded-xl p-3 text-center">
+              <Skeleton className="h-8 w-16 mx-auto mb-1" />
+              <Skeleton className="h-3 w-28 mx-auto" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Portfolio summary — 4 stat cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="bg-gray-900 border border-gray-800 rounded-2xl p-4 space-y-2">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-7 w-28" />
+          </div>
+        ))}
+      </div>
+
+      {/* Recent activity table — 5 rows */}
+      <div className="bg-gray-900 border border-gray-800 rounded-2xl overflow-hidden">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className={`flex items-center justify-between px-4 py-4 gap-4 ${
+              i < 4 ? "border-b border-gray-800" : ""
+            }`}
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <Skeleton className="h-10 w-10 rounded-full shrink-0" />
+              <div className="space-y-1.5 min-w-0">
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+            </div>
+            <div className="flex flex-col items-end gap-1 shrink-0">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default PortfolioSkeleton;


### PR DESCRIPTION
- Add MarketListSkeleton (6-card grid matching markets list layout)
- Add MarketDetailSkeleton (two-column layout with chart, prices, trade panel)
- Add PortfolioSkeleton (profile card + 4 stat cards + 5-row activity table)
- Add LeaderboardSkeleton (3 stat cards + 10-row table)
- Wire MarketListSkeleton into home page (replaces 4-card spinner)
- Wire MarketDetailSkeleton into markets/[id] page (replaces blank loading)
- Wire PortfolioSkeleton into profile page (replaces animate-pulse text)
- Wire LeaderboardSkeleton into leaderboard page (adds useQuery + skeleton)
- All skeletons use .skeleton class with 1.5s shimmer animation from globals.css
- Zero CLS: skeleton dimensions exactly match loaded content layout
- 31 unit tests covering all 4 new skeleton variants (100% pass)

Closes #505

## Summary
Brief description of what this PR does.

## Related Issue
Closes #(issue number)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (describe):

## Changes Made
- 
- 

## Testing
Describe how you tested your changes.

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented complex logic where necessary
- [ ] I have updated documentation if needed
- [ ] My changes don't introduce new warnings or errors
