### PR TITLE
feat: implement circuit breaker lock in Soroban contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,27 @@ resolve_market(market_id, winning_outcome)  // oracle-triggered
 distribute_rewards(market_id)
 ```
 
+## 🚨 Circuit Breaker
+
+The Soroban prediction market contract includes a per-market circuit breaker to slow down abnormal pool movement.
+
+- Each market stores a persistent `CircuitBreaker(market_id)` flag and a persistent `PoolSnapshot(market_id)` checkpoint.
+- On every `place_bet`, the contract compares the live pool against the last checkpoint once that checkpoint is at least 60 seconds old.
+- If pool movement is greater than 50% over that 60-second window, the contract flips the breaker on and emits a `breaker` contract event with the snapshot and current pool values.
+- Once active, all later `place_bet` calls fail with `CIRCUIT_BREAKER_ACTIVE` until an admin intervenes.
+
+### Breaker States
+
+- `inactive`: betting proceeds normally and the rolling pool snapshot is refreshed every 60 seconds.
+- `active`: new bets are rejected, but admin recovery actions remain available.
+- `resolved`: if the admin force-resolves the market, no new bets are accepted because the market is finalized.
+
+### Admin Recovery Procedure
+
+- Use `reopen_market(market_id)` to clear the breaker flag and reset the 60-second pool checkpoint to the current pool size.
+- Use `force_resolve(market_id, outcome)` if the market should be settled immediately instead of reopened.
+- `set_paused(market_id, true)` remains available as a separate manual pause control; reopening the breaker does not change the manual pause flag.
+
 ---
 
 ## 🪙 Token Model (Optional)

--- a/contracts/prediction_market/Cargo.lock
+++ b/contracts/prediction_market/Cargo.lock
@@ -213,16 +213,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -658,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -736,12 +735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "platforms"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22ff26099e927412d085a6c2dc539ad50ba69eab451b19846fef40373a3f645"
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,18 +777,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -888,18 +881,28 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1239,9 +1242,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1270,30 +1273,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/contracts/prediction_market/src/lib.rs
+++ b/contracts/prediction_market/src/lib.rs
@@ -1,12 +1,15 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token, Address, Env, Map, String, Vec,
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env, Map, String, Vec,
 };
 
 /// Maximum winners processed per batch_distribute call.
 /// Keeps CPU instruction count well below Soroban's per-tx ceiling (~100M instructions).
 /// At ~500k instructions per transfer, 25 winners ≈ 12.5M instructions — safe headroom.
 pub const MAX_BATCH_SIZE: u32 = 25;
+pub const CIRCUIT_BREAKER_WINDOW_SECS: u64 = 60;
+pub const CIRCUIT_BREAKER_THRESHOLD_PERCENT: i128 = 50;
+pub const CIRCUIT_BREAKER_ACTIVE: &str = "CIRCUIT_BREAKER_ACTIVE";
 
 #[contracttype]
 pub enum DataKey {
@@ -21,6 +24,12 @@ pub enum DataKey {
     IsPaused(u64),
     /// Hot: settlement cursor (index into winners vec) — Instance storage
     SettlementCursor(u64),
+    /// Persistent circuit breaker flag per market.
+    /// Stored durably so the lock survives across transactions once triggered.
+    CircuitBreaker(u64),
+    /// Persistent rolling pool checkpoint per market.
+    /// We update this every 60 seconds and compare the live pool against it.
+    PoolSnapshot(u64),
     /// Hot: global platform status — Instance storage.
     /// true = active (default), false = graceful shutdown.
     /// Only blocks create_market; existing markets resolve and pay out normally.
@@ -39,6 +48,23 @@ pub struct Market {
     pub token: Address,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PoolSnapshot {
+    pub timestamp: u64,
+    pub total_pool: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CircuitBreakerEvent {
+    pub market_id: u64,
+    pub snapshot_timestamp: u64,
+    pub snapshot_pool: i128,
+    pub current_pool: i128,
+    pub triggered_at: u64,
+}
+
 #[contract]
 pub struct PredictionMarket;
 
@@ -49,6 +75,119 @@ fn check_initialized(env: &Env) {
         .get(&DataKey::Initialized)
         .unwrap_or(false);
     assert!(!is_init, "Contract already initialized");
+}
+
+fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+fn get_market_or_panic(env: &Env, market_id: u64) -> Market {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Market(market_id))
+        .unwrap()
+}
+
+fn resolve_market_internal(env: &Env, market_id: u64, winning_outcome: u32) {
+    let mut market = get_market_or_panic(env, market_id);
+
+    assert!(!market.resolved, "Already resolved");
+    assert!(
+        winning_outcome < market.options.len(),
+        "Invalid outcome index"
+    );
+
+    market.resolved = true;
+    market.winning_outcome = winning_outcome;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Market(market_id), &market);
+}
+
+fn get_total_shares_internal(env: &Env, market_id: u64) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalShares(market_id))
+        .unwrap_or(0)
+}
+
+fn get_pool_snapshot_internal(env: &Env, market_id: u64) -> PoolSnapshot {
+    env.storage()
+        .persistent()
+        .get(&DataKey::PoolSnapshot(market_id))
+        .unwrap_or(PoolSnapshot {
+            timestamp: env.ledger().timestamp(),
+            total_pool: 0,
+        })
+}
+
+fn set_pool_snapshot(env: &Env, market_id: u64, total_pool: i128) {
+    env.storage().persistent().set(
+        &DataKey::PoolSnapshot(market_id),
+        &PoolSnapshot {
+            timestamp: env.ledger().timestamp(),
+            total_pool,
+        },
+    );
+}
+
+fn get_circuit_breaker_internal(env: &Env, market_id: u64) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CircuitBreaker(market_id))
+        .unwrap_or(false)
+}
+
+fn set_circuit_breaker_internal(env: &Env, market_id: u64, active: bool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CircuitBreaker(market_id), &active);
+}
+
+fn pool_movement_exceeds_threshold(snapshot_pool: i128, current_pool: i128) -> bool {
+    if snapshot_pool <= 0 {
+        return false;
+    }
+
+    let movement = if current_pool >= snapshot_pool {
+        current_pool - snapshot_pool
+    } else {
+        snapshot_pool - current_pool
+    };
+
+    movement * 100 > snapshot_pool * CIRCUIT_BREAKER_THRESHOLD_PERCENT
+}
+
+fn maybe_trigger_circuit_breaker(env: &Env, market_id: u64, current_pool: i128) {
+    let snapshot = get_pool_snapshot_internal(env, market_id);
+    let now = env.ledger().timestamp();
+
+    if snapshot.total_pool == 0 {
+        set_pool_snapshot(env, market_id, current_pool);
+        return;
+    }
+
+    if now.saturating_sub(snapshot.timestamp) < CIRCUIT_BREAKER_WINDOW_SECS {
+        return;
+    }
+
+    // Compare against the prior 60-second checkpoint first, then roll the checkpoint
+    // forward. This keeps the hot path deterministic while preserving a durable audit trail.
+    if pool_movement_exceeds_threshold(snapshot.total_pool, current_pool) {
+        set_circuit_breaker_internal(env, market_id, true);
+        env.events().publish(
+            (symbol_short!("breaker"), market_id),
+            CircuitBreakerEvent {
+                market_id,
+                snapshot_timestamp: snapshot.timestamp,
+                snapshot_pool: snapshot.total_pool,
+                current_pool,
+                triggered_at: now,
+            },
+        );
+    }
+
+    set_pool_snapshot(env, market_id, current_pool);
 }
 
 #[contractimpl]
@@ -75,7 +214,7 @@ impl PredictionMarket {
         deadline: u64,
         token: Address,
     ) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
         // Graceful shutdown guard — checked before any other work
@@ -107,14 +246,23 @@ impl PredictionMarket {
         };
 
         // Cold: market metadata + user positions map → Persistent
-        env.storage().persistent().set(&DataKey::Market(id), &market);
         env.storage()
             .persistent()
-            .set(&DataKey::UserPosition(id), &Map::<Address, (u32, i128)>::new(&env));
+            .set(&DataKey::Market(id), &market);
+        env.storage().persistent().set(
+            &DataKey::UserPosition(id),
+            &Map::<Address, (u32, i128)>::new(&env),
+        );
 
         // Hot: total_shares + is_paused → Instance (cheaper reads/writes)
-        env.storage().instance().set(&DataKey::TotalShares(id), &0i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalShares(id), &0i128);
         env.storage().instance().set(&DataKey::IsPaused(id), &false);
+        // Persistent breaker state survives across transactions and lets us inspect
+        // the last 60-second checkpoint even after the market is locked.
+        set_circuit_breaker_internal(&env, id, false);
+        set_pool_snapshot(&env, id, 0);
     }
 
     /// Place a bet on an option.
@@ -130,13 +278,12 @@ impl PredictionMarket {
             .get(&DataKey::IsPaused(market_id))
             .unwrap_or(false);
         assert!(!paused, "Market is paused");
+        if get_circuit_breaker_internal(&env, market_id) {
+            panic!("{}", CIRCUIT_BREAKER_ACTIVE);
+        }
 
         // Cold read: market metadata from Persistent
-        let market: Market = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Market(market_id))
-            .unwrap();
+        let market = get_market_or_panic(&env, market_id);
 
         assert!(!market.resolved, "Market already resolved");
         assert!(
@@ -160,20 +307,19 @@ impl PredictionMarket {
             .set(&DataKey::UserPosition(market_id), &positions);
 
         // Hot write: total_shares → Instance (avoids expensive Persistent write on every bet)
-        let shares: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::TotalShares(market_id))
-            .unwrap_or(0);
+        let shares = get_total_shares_internal(&env, market_id);
+        let updated_pool = shares + amount;
         env.storage()
             .instance()
-            .set(&DataKey::TotalShares(market_id), &(shares + amount));
+            .set(&DataKey::TotalShares(market_id), &updated_pool);
+
+        maybe_trigger_circuit_breaker(&env, market_id, updated_pool);
     }
 
     /// Pause or unpause a market (admin only).
     /// Writes to Instance storage — single cheap write.
     pub fn set_paused(env: Env, market_id: u64, paused: bool) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
         env.storage()
             .instance()
@@ -185,7 +331,7 @@ impl PredictionMarket {
     /// active=true  → platform re-opened.
     /// Single Instance write — cheapest possible admin action.
     pub fn set_global_status(env: Env, active: bool) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
         env.storage()
             .instance()
@@ -202,26 +348,27 @@ impl PredictionMarket {
 
     /// Resolve market — only admin (oracle-triggered).
     pub fn resolve_market(env: Env, market_id: u64, winning_outcome: u32) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
+        resolve_market_internal(&env, market_id, winning_outcome);
+    }
 
-        let mut market: Market = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Market(market_id))
-            .unwrap();
+    /// Admin recovery path after a breaker trigger.
+    /// Clears the persistent lock and refreshes the rolling checkpoint to the current pool.
+    pub fn reopen_market(env: Env, market_id: u64) {
+        let admin = get_admin(&env);
+        admin.require_auth();
+        let _ = get_market_or_panic(&env, market_id);
+        set_circuit_breaker_internal(&env, market_id, false);
+        set_pool_snapshot(&env, market_id, get_total_shares_internal(&env, market_id));
+    }
 
-        assert!(!market.resolved, "Already resolved");
-        assert!(
-            winning_outcome < market.options.len(),
-            "Invalid outcome index"
-        );
-
-        market.resolved = true;
-        market.winning_outcome = winning_outcome;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Market(market_id), &market);
+    /// Emergency admin resolution path.
+    /// Useful when a breaker-triggered market should be finalized instead of reopened.
+    pub fn force_resolve(env: Env, market_id: u64, winning_outcome: u32) {
+        let admin = get_admin(&env);
+        admin.require_auth();
+        resolve_market_internal(&env, market_id, winning_outcome);
     }
 
     /// Batch-distribute rewards to at most `batch_size` winners per call.
@@ -323,18 +470,12 @@ impl PredictionMarket {
 
     /// Read a market's stored metadata.
     pub fn get_market(env: Env, market_id: u64) -> Market {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Market(market_id))
-            .unwrap()
+        get_market_or_panic(&env, market_id)
     }
 
     /// Get total shares for a market (hot read from Instance).
     pub fn get_total_shares(env: Env, market_id: u64) -> i128 {
-        env.storage()
-            .instance()
-            .get(&DataKey::TotalShares(market_id))
-            .unwrap_or(0)
+        get_total_shares_internal(&env, market_id)
     }
 
     /// Get pause state for a market (hot read from Instance).
@@ -344,12 +485,25 @@ impl PredictionMarket {
             .get(&DataKey::IsPaused(market_id))
             .unwrap_or(false)
     }
+
+    /// Read the persistent circuit breaker flag for a market.
+    pub fn get_circuit_breaker(env: Env, market_id: u64) -> bool {
+        get_circuit_breaker_internal(&env, market_id)
+    }
+
+    /// Read the latest persistent pool checkpoint for a market.
+    pub fn get_pool_snapshot(env: Env, market_id: u64) -> PoolSnapshot {
+        get_pool_snapshot_internal(&env, market_id)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, vec, Env, String};
+    use soroban_sdk::{
+        testutils::{Address as _, Events as _, Ledger as _},
+        vec, Env, String, Symbol, TryFromVal,
+    };
 
     // ── shared helpers ────────────────────────────────────────────────────────
 
@@ -370,8 +524,7 @@ mod tests {
         let contract_id = env.register_contract(None, PredictionMarket);
         let client = PredictionMarketClient::new(&env, &contract_id);
         let admin = Address::generate(&env);
-        // Use a dummy address for token — tests that don't do real transfers use mock_all_auths
-        let token = Address::generate(&env);
+        let token = setup_token(&env, &[]);
         client.initialize(&admin);
         let deadline = env.ledger().timestamp() + 86400;
         let question = String::from_str(&env, "Will BTC exceed $100k?");
@@ -384,11 +537,43 @@ mod tests {
         (env, client, admin, token, deadline)
     }
 
+    fn setup_with_real_token(
+        market_id: u64,
+    ) -> (
+        Env,
+        PredictionMarketClient<'static>,
+        Address,
+        Address,
+        Address,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, PredictionMarket);
+        let client = PredictionMarketClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let bettor = Address::generate(&env);
+        let token = setup_token(&env, &[(&bettor, 1_000i128)]);
+
+        client.initialize(&admin);
+        client.create_market(
+            &market_id,
+            &String::from_str(&env, "Circuit breaker market"),
+            &vec![
+                &env,
+                String::from_str(&env, "Yes"),
+                String::from_str(&env, "No"),
+            ],
+            &(env.ledger().timestamp() + 86400),
+            &token,
+        );
+
+        (env, client, admin, bettor, token)
+    }
+
     /// Build a market with `n` winners (option 0) and 1 loser (option 1),
     /// using a real SAC token so transfers actually execute.
-    fn setup_market_with_winners(
-        n: u32,
-    ) -> (Env, PredictionMarketClient<'static>, Vec<Address>) {
+    fn setup_market_with_winners(n: u32) -> (Env, PredictionMarketClient<'static>, Vec<Address>) {
         let env = Env::default();
         env.mock_all_auths();
 
@@ -450,7 +635,13 @@ mod tests {
         assert_eq!(market.options.len(), 2);
         assert_eq!(market.deadline, deadline);
         assert!(!market.resolved);
-        soroban_sdk::log!(&env, "✅ Market stored: id={}, deadline={}, resolved={}", market.id, market.deadline, market.resolved);
+        soroban_sdk::log!(
+            &env,
+            "✅ Market stored: id={}, deadline={}, resolved={}",
+            market.id,
+            market.deadline,
+            market.resolved
+        );
     }
 
     #[test]
@@ -482,7 +673,9 @@ mod tests {
         let client = PredictionMarketClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        let token_addr = Address::generate(&env);
+        let bettor1 = Address::generate(&env);
+        let bettor2 = Address::generate(&env);
+        let token_addr = setup_token(&env, &[(&bettor1, 1_000i128), (&bettor2, 1_000i128)]);
         client.initialize(&admin);
 
         let deadline = env.ledger().timestamp() + 86400;
@@ -499,22 +692,6 @@ mod tests {
             &token_addr,
         );
 
-        // Register a mock token contract so transfers succeed
-        let token_contract = env.register_stellar_asset_contract_v2(token_addr.clone());
-        let token_admin = soroban_sdk::testutils::MockAuth {
-            address: &token_addr,
-            invoke: &soroban_sdk::testutils::MockAuthInvoke {
-                contract: &token_contract.address(),
-                fn_name: "transfer",
-                args: soroban_sdk::vec![&env].into(),
-                sub_invokes: &[],
-            },
-        };
-        let _ = token_admin; // suppress unused warning — mock_all_auths covers this
-
-        let bettor1 = Address::generate(&env);
-        let bettor2 = Address::generate(&env);
-
         client.place_bet(&2u64, &0u32, &bettor1, &100i128);
         client.place_bet(&2u64, &1u32, &bettor2, &200i128);
 
@@ -527,6 +704,14 @@ mod tests {
     fn test_is_paused_defaults_false() {
         let (_, client, _, _, _) = setup();
         assert!(!client.get_is_paused(&1u64));
+    }
+
+    #[test]
+    fn test_circuit_breaker_defaults_false() {
+        let (_, client, _, _, _) = setup();
+        assert!(!client.get_circuit_breaker(&1u64));
+        let snapshot = client.get_pool_snapshot(&1u64);
+        assert_eq!(snapshot.total_pool, 0i128);
     }
 
     #[test]
@@ -731,6 +916,119 @@ mod tests {
         client.place_bet(&1u64, &0u32, &bettor, &50i128);
     }
 
+    // ── Circuit breaker ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_circuit_breaker_triggers_after_sixty_second_pool_spike() {
+        let (env, client, _, bettor, _) = setup_with_real_token(6u64);
+
+        client.place_bet(&6u64, &0u32, &bettor, &100i128);
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + CIRCUIT_BREAKER_WINDOW_SECS + 1);
+        client.place_bet(&6u64, &0u32, &bettor, &60i128);
+
+        assert!(client.get_circuit_breaker(&6u64));
+        assert_eq!(client.get_total_shares(&6u64), 160i128);
+
+        let mut found = false;
+        for (_, topics, data) in env.events().all().iter() {
+            if topics.len() == 2 {
+                let topic0 = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+                let topic1 = u64::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+                if topic0 == symbol_short!("breaker") && topic1 == 6u64 {
+                    let event = CircuitBreakerEvent::try_from_val(&env, &data).unwrap();
+                    assert_eq!(
+                        event,
+                        CircuitBreakerEvent {
+                            market_id: 6u64,
+                            snapshot_timestamp: 0u64,
+                            snapshot_pool: 100i128,
+                            current_pool: 160i128,
+                            triggered_at: CIRCUIT_BREAKER_WINDOW_SECS + 1,
+                        }
+                    );
+                    found = true;
+                }
+            }
+        }
+        assert!(found, "expected circuit breaker event");
+    }
+
+    #[test]
+    #[should_panic(expected = "CIRCUIT_BREAKER_ACTIVE")]
+    fn test_place_bet_blocked_after_circuit_breaker_trigger() {
+        let (env, client, _, bettor, _) = setup_with_real_token(7u64);
+
+        client.place_bet(&7u64, &0u32, &bettor, &100i128);
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + CIRCUIT_BREAKER_WINDOW_SECS + 1);
+        client.place_bet(&7u64, &0u32, &bettor, &60i128);
+
+        client.place_bet(&7u64, &0u32, &bettor, &10i128);
+    }
+
+    #[test]
+    fn test_circuit_breaker_does_not_trigger_at_exactly_fifty_percent() {
+        let (env, client, _, bettor, _) = setup_with_real_token(8u64);
+
+        client.place_bet(&8u64, &0u32, &bettor, &100i128);
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + CIRCUIT_BREAKER_WINDOW_SECS + 1);
+        client.place_bet(&8u64, &0u32, &bettor, &50i128);
+
+        assert!(!client.get_circuit_breaker(&8u64));
+        let snapshot = client.get_pool_snapshot(&8u64);
+        assert_eq!(snapshot.total_pool, 150i128);
+    }
+
+    #[test]
+    fn test_circuit_breaker_does_not_trigger_inside_window() {
+        let (env, client, _, bettor, _) = setup_with_real_token(9u64);
+
+        client.place_bet(&9u64, &0u32, &bettor, &100i128);
+        env.ledger().set_timestamp(env.ledger().timestamp() + 30);
+        client.place_bet(&9u64, &0u32, &bettor, &100i128);
+
+        assert!(!client.get_circuit_breaker(&9u64));
+        let snapshot = client.get_pool_snapshot(&9u64);
+        assert_eq!(snapshot.total_pool, 100i128);
+    }
+
+    #[test]
+    fn test_reopen_market_clears_circuit_breaker_and_refreshes_snapshot() {
+        let (env, client, _, bettor, _) = setup_with_real_token(10u64);
+
+        client.place_bet(&10u64, &0u32, &bettor, &100i128);
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + CIRCUIT_BREAKER_WINDOW_SECS + 1);
+        client.place_bet(&10u64, &0u32, &bettor, &60i128);
+
+        client.reopen_market(&10u64);
+        assert!(!client.get_circuit_breaker(&10u64));
+
+        let snapshot = client.get_pool_snapshot(&10u64);
+        assert_eq!(snapshot.total_pool, 160i128);
+        assert_eq!(snapshot.timestamp, CIRCUIT_BREAKER_WINDOW_SECS + 1);
+
+        client.place_bet(&10u64, &0u32, &bettor, &10i128);
+        assert_eq!(client.get_total_shares(&10u64), 170i128);
+    }
+
+    #[test]
+    fn test_force_resolve_works_after_circuit_breaker_trigger() {
+        let (env, client, _, bettor, _) = setup_with_real_token(11u64);
+
+        client.place_bet(&11u64, &0u32, &bettor, &100i128);
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + CIRCUIT_BREAKER_WINDOW_SECS + 1);
+        client.place_bet(&11u64, &0u32, &bettor, &60i128);
+
+        client.force_resolve(&11u64, &0u32);
+        let market = client.get_market(&11u64);
+        assert!(market.resolved);
+        assert_eq!(market.winning_outcome, 0u32);
+    }
+
     // ── Batch distribute ──────────────────────────────────────────────────────
 
     /// Cursor starts at 0 before any settlement.
@@ -890,11 +1188,9 @@ mod tests {
     /// place_bet on an existing market still works during shutdown.
     #[test]
     fn test_place_bet_allowed_during_shutdown() {
-        let (env, client, _, _, _) = setup();
+        let (_, client, _, bettor, _) = setup_with_real_token(1u64);
         client.set_global_status(&false);
         // market 1 was created before shutdown — betting must still work
-        let bettor = Address::generate(&env);
-        // mock_all_auths covers token transfer; no panic expected
         client.place_bet(&1u64, &0u32, &bettor, &50i128);
         assert_eq!(client.get_total_shares(&1u64), 50i128);
     }


### PR DESCRIPTION
## Overview
This PR implements a per-market circuit breaker for the Soroban prediction market contract to protect pools from anomalous betting activity. It adds persistent circuit-breaker state and rolling pool snapshots, blocks new bets once the breaker is triggered, emits an on-chain event for indexers, and provides admin recovery flows to reopen or force-resolve affected markets.

## Related Issue
Closes #143

## Changes

### ⚙️ Circuit Breaker Implementation
- **[MODIFY]** `contracts/prediction_market/src/lib.rs`
  - Added `DataKey::CircuitBreaker(u64)` and `DataKey::PoolSnapshot(u64)` to contract storage.
  - Added a persistent circuit-breaker flag per market.
  - Added a persistent rolling pool snapshot per market.
  - On each `place_bet`, compares the current pool against the snapshot from at least 60 seconds earlier.
  - Triggers the circuit breaker when pool movement is greater than 50% within the 60-second window.
  - Rejects later bets with `CIRCUIT_BREAKER_ACTIVE` once the breaker is active.
  - Emits a `breaker` contract event with market ID, previous snapshot, current pool, and trigger timestamp.
  - Refreshes the stored pool snapshot using ledger timestamp checks.

### 🛠️ Admin Recovery Functions
- **[MODIFY]** `contracts/prediction_market/src/lib.rs`
  - Added `reopen_market(market_id)` to clear the breaker and refresh the snapshot baseline.
  - Added `force_resolve(market_id, outcome)` to allow emergency admin resolution.
  - Both recovery functions require admin auth.

### 🧪 Test Coverage
- **[MODIFY]** `contracts/prediction_market/src/lib.rs`
  - Added unit tests for:
    - breaker default state
    - trigger when movement exceeds 50% after 60 seconds
    - no trigger at exactly 50%
    - no trigger inside the 60-second window
    - bets blocked after trigger
    - admin reopen flow
    - admin force-resolve flow
  - Verified the full contract test suite passes.

### 📚 Documentation
- **[MODIFY]** `README.md`
  - Documented circuit breaker states.
  - Documented the admin recovery procedure.
  - Described how the 60-second snapshot and trigger threshold work.

### 📦 Dependency / Audit Maintenance
- **[MODIFY]** `contracts/prediction_market/Cargo.lock`
  - Updated lockfile dependencies so `cargo audit` passes without high or critical advisories.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Circuit breaker triggers correctly when pool movement exceeds 50% within 60 seconds | ✅ |
| New bets are rejected with `CIRCUIT_BREAKER_ACTIVE` after trigger | ✅ |
| Contract event is emitted on trigger | ✅ |
| `reopen_market` and `force_resolve` require admin auth and work correctly | ✅ |
| Unit tests cover trigger and recovery edge cases | ✅ |
| `cargo audit` passes with zero high or critical advisories | ✅ |
| README documents breaker states and recovery procedure | ✅ |

## How to Test

```bash
# 1. Confirm you're on the feature branch
git branch --show-current

# 2. Run the contract tests
cd contracts/prediction_market
cargo test
<img width="808" height="393" alt="image" src="https://github.com/user-attachments/assets/f6fd42a1-2c79-4b11-98ae-eb1dbb921989" />

# 3. Verify dependency audit
cargo audit

# 4. Optional: inspect the main changed files
git diff -- README.md contracts/prediction_market/src/lib.rs contracts/prediction_market/Cargo.lock
```