### PR TITLE
fix(oracle): handle CoinGecko 429 rate limit with retry and API key s…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ SPORTS_API_URL=https://v3.football.api-sports.io
 # NEVER commit this value. Add to your secrets manager / CI env.
 CMC_API_KEY=your_coinmarketcap_api_key_here
 
+# CoinGecko API key — optional but recommended to avoid free-tier rate limits (10-30 req/min).
+# Get a free Demo key at https://www.coingecko.com/en/api
+# NEVER commit this value. Add to your secrets manager / CI env.
+COINGECKO_API_KEY=your_coingecko_api_key_here
+
 # Sports Oracle — Stellar on-chain resolution
 # ORACLE_SECRET_KEY must NEVER be committed. Add to your secrets manager / CI env.
 ORACLE_SECRET_KEY=your_stellar_oracle_secret_key_here

--- a/oracle/index.js
+++ b/oracle/index.js
@@ -1,7 +1,7 @@
 require("dotenv").config();
 const axios = require("axios");
 const { OracleMedianizer } = require("./medianizer");
-const { btcSources } = require("./sources");
+const { btcSources, RateLimitError } = require("./sources");
 
 const API_URL = process.env.API_URL || "http://localhost:4000";
 
@@ -101,6 +101,13 @@ async function resolveMarket(market) {
     await axios.post(`${API_URL}/api/markets/${market.id}/resolve`, { winningOutcome });
     logger.info(`[Oracle] Market #${market.id} resolved → outcome index: ${winningOutcome}`);
   } catch (err) {
+    // CoinGecko rate limit — retry after the server-specified delay
+    if (err instanceof RateLimitError) {
+      const delayMs = err.retryAfter * 1000;
+      logger.warn(`[Oracle] Market #${market.id} hit CoinGecko rate limit — retrying in ${err.retryAfter}s`);
+      setTimeout(() => resolveMarket(market), delayMs);
+      return;
+    }
     // #377: Handle deadline not reached errors gracefully
     if (err.response?.data?.error?.includes("Market deadline not reached")) {
       logger.warn(`[Oracle] Market #${market.id} deadline not reached on-chain, retrying in 5 minutes`);
@@ -275,6 +282,7 @@ module.exports = {
   markUnresolvable,
   gracefulShutdown,
   reschedule,
+  RateLimitError,
   _getIsRunning: () => isRunning,
   _getIsShuttingDown: () => isShuttingDown,
   _getIntervalHandle: () => intervalHandle,

--- a/oracle/sources.js
+++ b/oracle/sources.js
@@ -18,13 +18,60 @@
 
 const axios = require("axios");
 
-/** Source 1: CoinGecko — free, no API key required */
+/** Thrown when CoinGecko returns HTTP 429 — caller should retry after `retryAfter` seconds */
+class RateLimitError extends Error {
+  constructor(retryAfter = 60) {
+    super(`CoinGecko rate limit exceeded — retry after ${retryAfter}s`);
+    this.name = "RateLimitError";
+    this.retryAfter = retryAfter;
+  }
+}
+
+// ── Request counter for rate-limit proximity warning ─────────────────────────
+// CoinGecko free tier: ~10-30 req/min. Warn at RATE_LIMIT_WARN_THRESHOLD.
+const RATE_LIMIT_WARN_THRESHOLD = 8;
+let _cgRequestCount = 0;
+let _cgWindowStart = Date.now();
+
+function trackCoinGeckoRequest() {
+  const now = Date.now();
+  // Reset counter every 60 seconds
+  if (now - _cgWindowStart >= 60_000) {
+    _cgRequestCount = 0;
+    _cgWindowStart = now;
+  }
+  _cgRequestCount++;
+  if (_cgRequestCount >= RATE_LIMIT_WARN_THRESHOLD) {
+    console.warn(
+      `[Oracle] CoinGecko request count approaching rate limit: ${_cgRequestCount} requests in current window`
+    );
+  }
+}
+
+/** Source 1: CoinGecko — optional API key via COINGECKO_API_KEY env var */
 async function fetchCoinGecko() {
-  const { data } = await axios.get(
+  trackCoinGeckoRequest();
+
+  const headers = {};
+  if (process.env.COINGECKO_API_KEY) {
+    headers["x-cg-demo-api-key"] = process.env.COINGECKO_API_KEY;
+  }
+
+  const response = await axios.get(
     "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
-    { timeout: 5000 }
+    { timeout: 5000, headers, validateStatus: null }
   );
-  return data.bitcoin.usd;
+
+  if (response.status === 429) {
+    const retryAfter = parseInt(response.headers["retry-after"] ?? "60", 10);
+    throw new RateLimitError(retryAfter);
+  }
+
+  if (response.status !== 200) {
+    throw new Error(`CoinGecko returned HTTP ${response.status}`);
+  }
+
+  return response.data.bitcoin.usd;
 }
 
 /** Source 2: Binance public ticker — no API key required */
@@ -88,6 +135,7 @@ async function fetchCoinMarketCap() {
 const btcSources = [fetchCoinGecko, fetchBinance, fetchCoinbase, fetchKraken, fetchCoinMarketCap];
 
 module.exports = {
+  RateLimitError,
   btcSources,
   fetchCoinGecko,
   fetchBinance,


### PR DESCRIPTION
fix(oracle): handle CoinGecko 429 rate limit with retry and API key support

## Problem

The CoinGecko price source called the public API endpoint with no authentication. The free tier allows only 10–30 
requests/min. During cycles with multiple active crypto markets, the oracle would hit this limit, receive 429 
responses, and silently resolve all rate-limited markets to outcome 0 — causing incorrect resolutions.

## Root Cause

fetchCoinGecko in oracle/sources.js had no API key header, no status code inspection, and no 429 detection. 
resolveMarket in oracle/index.js had no handling for rate limit errors, so they fell through to the generic error 
handler without retrying.

## Changes

oracle/sources.js
- Added RateLimitError class — carries retryAfter (seconds) parsed from the retry-after response header
- Added per-minute request counter that logs a warn when approaching the free-tier limit (threshold: 8 req/min)
- fetchCoinGecko now sends x-cg-demo-api-key header when COINGECKO_API_KEY is set
- Uses validateStatus: null to inspect status codes directly; throws RateLimitError on 429, plain Error on other non-
200 responses

oracle/index.js
- Imports RateLimitError from ./sources
- resolveMarket catches RateLimitError specifically and reschedules the market via setTimeout using the server-
specified retryAfter delay — no silent fallback to outcome 0

.env.example
- Added COINGECKO_API_KEY with a comment pointing to the CoinGecko API signup page

## Testing

- Set COINGECKO_API_KEY in your .env to verify the header is sent
- Mock a 429 response with a retry-after: 30 header and confirm the market is retried after 30s and not resolved to 
outcome 0

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor

closes #489 