### PR TITLE
fix: resolve stale odds, payout concurrency, dev faucet, and oracle retry handling

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -75,6 +75,8 @@ function applyRoutes(app) {
 
   // Prometheus metrics — NOT behind App Check so Prometheus can scrape freely
   app.use("/metrics", require("./routes/metrics"));
+  // Development-only tooling is guarded inside the route handler by NODE_ENV.
+  app.use("/api/dev", require("./routes/dev"));
 
   // ── App Check enforcement ─────────────────────────────────────────────────
   // All /api/* routes are protected. Any request without a valid

--- a/backend/src/routes/bets.js
+++ b/backend/src/routes/bets.js
@@ -69,84 +69,115 @@ router.post("/", async (req, res) => {
 
 // POST /api/bets/payout/:marketId — distribute rewards to winners
 router.post("/payout/:marketId", async (req, res) => {
+  const marketId = req.params.marketId;
+  let client;
+  let inTransaction = false;
+
   try {
-    const market = await db.query(
-      "SELECT * FROM markets WHERE id = $1 AND resolved = TRUE",
-      [req.params.marketId]
+    client = await db.connect();
+    await client.query("BEGIN");
+    inTransaction = true;
+    await client.query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE");
+
+    const market = await client.query(
+      "SELECT id, winning_outcome, total_pool FROM markets WHERE id = $1 AND resolved = TRUE FOR UPDATE",
+      [marketId]
     );
     if (!market.rows.length) {
-      logger.warn({ market_id: req.params.marketId }, "Payout rejected: market not resolved");
+      await client.query("ROLLBACK");
+      inTransaction = false;
+      logger.warn({ market_id: marketId }, "Payout rejected: market not resolved");
       return res.status(400).json({ error: "Market not resolved yet" });
     }
 
     const { winning_outcome, total_pool } = market.rows[0];
-
-    // Get all winning bets
-    const winners = await db.query(
-      "SELECT * FROM bets WHERE market_id = $1 AND outcome_index = $2 AND paid_out = FALSE",
-      [req.params.marketId, winning_outcome]
+    const lockedWinners = await client.query(
+      "SELECT id, wallet_address, amount, paid_out FROM bets WHERE market_id = $1 AND outcome_index = $2 FOR UPDATE",
+      [marketId, winning_outcome]
     );
 
-    // Convert to stroops (7 decimal places = 10^7)
-    const STROOP_MULTIPLIER = 10_000_000n;
+    const winners = lockedWinners.rows.filter((row) => row.paid_out === false);
+    const alreadyPaid = lockedWinners.rows.filter((row) => row.paid_out === true);
+    for (const bet of alreadyPaid) {
+      logger.warn({ market_id: marketId, bet_id: bet.id }, "Skipping payout row already marked as paid_out");
+    }
+
     const totalPoolStroops = BigInt(Math.floor(parseFloat(total_pool) * 1e7));
-    
-    // Get total winning stake in stroops
-    const winningStakeStroops = winners.rows.reduce((sum, b) => {
+    const winningStakeStroops = winners.reduce((sum, b) => {
       return sum + BigInt(Math.floor(parseFloat(b.amount) * 1e7));
     }, 0n);
 
     if (winningStakeStroops === 0n) {
+      await client.query("ROLLBACK");
+      inTransaction = false;
       return res.status(400).json({ error: "No winning stake" });
     }
 
-    // Calculate payout pool after 3% platform fee: pool * 97 / 100
     const payoutPoolStroops = (totalPoolStroops * 97n) / 100n;
-
-    // Calculate payouts using BigInt arithmetic
-    const payouts = winners.rows.map((bet) => {
+    const payouts = winners.map((bet) => {
       const betAmountStroops = BigInt(Math.floor(parseFloat(bet.amount) * 1e7));
-      // payout = (betAmount * payoutPool) / winningStake
       const payoutStroops = (betAmountStroops * payoutPoolStroops) / winningStakeStroops;
-      // Convert back to XLM (divide by 10^7)
       const payoutXlm = Number(payoutStroops) / 1e7;
-      return { wallet: bet.wallet_address, payout: payoutXlm.toFixed(7) };
+      return { betId: bet.id, wallet: bet.wallet_address, payout: payoutXlm.toFixed(7) };
     });
 
-    // Verify sum of payouts doesn't exceed payout pool
     let totalPayoutStroops = 0n;
     for (const payout of payouts) {
       const payoutStroops = BigInt(Math.round(parseFloat(payout.payout) * 10_000_000));
       totalPayoutStroops += payoutStroops;
     }
 
-    if (totalPayoutStroops > payoutPool) {
+    if (totalPayoutStroops > payoutPoolStroops) {
       logger.error({
-        market_id: req.params.marketId,
+        market_id: marketId,
         total_payout_stroops: totalPayoutStroops.toString(),
-        payout_pool_stroops: payoutPool.toString(),
+        payout_pool_stroops: payoutPoolStroops.toString(),
       }, "Payout sum exceeds pool");
+      await client.query("ROLLBACK");
+      inTransaction = false;
       return res.status(500).json({ error: "Payout calculation error: sum exceeds pool" });
     }
 
-    // Mark bets as paid
-    await db.query(
-      "UPDATE bets SET paid_out = TRUE WHERE market_id = $1 AND outcome_index = $2",
-      [req.params.marketId, winning_outcome]
+    const winnerIds = winners.map((w) => w.id);
+    const markedPaid = await client.query(
+      "UPDATE bets SET paid_out = TRUE WHERE id = ANY($1::int[]) AND paid_out = FALSE RETURNING id, wallet_address",
+      [winnerIds]
     );
+    const markedPaidIds = new Set(markedPaid.rows.map((row) => row.id));
+    const committedPayouts = payouts
+      .filter((p) => markedPaidIds.has(p.betId))
+      .map(({ wallet, payout }) => ({ wallet, payout }));
+
+    await client.query("COMMIT");
+    inTransaction = false;
 
     logger.info({
-      market_id: req.params.marketId,
+      market_id: marketId,
       winning_outcome,
-      winners_count: winners.rows.length,
+      winners_count: committedPayouts.length,
       total_pool,
       winning_stake: Number(winningStakeStroops) / 1e7,
     }, "Payouts distributed");
 
-    res.json({ payouts });
+    res.json({ payouts: committedPayouts });
   } catch (err) {
-    logger.error({ err, market_id: req.params.marketId }, "Failed to distribute payouts");
+    if (client && inTransaction) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (rollbackErr) {
+        logger.error({ err: rollbackErr, market_id: marketId }, "Payout rollback failed");
+      }
+    }
+    if (err?.code === "40001") {
+      logger.warn({ market_id: marketId }, "Payout serialization conflict");
+      return res.status(409).json({ error: "Concurrent payout conflict, please retry" });
+    }
+    logger.error({ err, market_id: marketId }, "Failed to distribute payouts");
     res.status(500).json({ error: err.message });
+  } finally {
+    if (client) {
+      client.release();
+    }
   }
 });
 

--- a/backend/src/routes/dev.js
+++ b/backend/src/routes/dev.js
@@ -1,0 +1,71 @@
+"use strict";
+
+const express = require("express");
+const axios = require("axios");
+const redis = require("../utils/redis");
+const logger = require("../utils/logger");
+
+const router = express.Router();
+const ONE_HOUR_SECONDS = 60 * 60;
+
+function isDevEnvironment() {
+  return process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+}
+
+router.get("/faucet", async (req, res) => {
+  if (!isDevEnvironment()) {
+    return res.status(403).json({ error: "Faucet is only available in development." });
+  }
+
+  const wallet = String(req.query.wallet || "").trim();
+  if (!wallet) {
+    return res.status(400).json({ error: "wallet query parameter is required" });
+  }
+
+  if (!/^G[A-Z2-7]{55}$/.test(wallet)) {
+    return res.status(400).json({ error: "Invalid Stellar wallet address" });
+  }
+
+  const rateLimitKey = `faucet:wallet:${wallet}`;
+
+  try {
+    const claimLock = await redis.set(rateLimitKey, String(Date.now()), "EX", ONE_HOUR_SECONDS, "NX");
+    if (claimLock !== "OK") {
+      return res.status(429).json({ error: "Rate limit exceeded. Try again in one hour." });
+    }
+
+    const friendbotResponse = await axios.get("https://friendbot.stellar.org", {
+      params: { addr: wallet },
+    });
+    const transactionHash =
+      friendbotResponse.data?.hash ??
+      friendbotResponse.data?.transaction_hash ??
+      friendbotResponse.data?.tx_hash ??
+      null;
+
+    return res.status(200).json({
+      ...friendbotResponse.data,
+      transaction_hash: transactionHash,
+    });
+  } catch (err) {
+    await redis.del(rateLimitKey).catch(() => {});
+
+    logger.error(
+      {
+        wallet_address: wallet,
+        error: err.message,
+      },
+      "Friendbot faucet request failed"
+    );
+
+    const upstreamStatus = err.response?.status;
+    const upstreamBody = err.response?.data;
+
+    return res.status(upstreamStatus || 502).json({
+      error: upstreamBody?.detail || upstreamBody?.error || "Failed to request testnet funds",
+      details: upstreamBody || null,
+    });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/tests/bets.payout-concurrency.test.js
+++ b/backend/src/routes/tests/bets.payout-concurrency.test.js
@@ -7,13 +7,6 @@ jest.mock("../../utils/logger", () => ({
   error: jest.fn(),
 }));
 jest.mock("../../bots/eventBus", () => ({ emit: jest.fn() }));
-jest.mock("../../websocket/marketUpdates", () => ({ broadcastBetPlaced: jest.fn() }));
-jest.mock("../../utils/sorobanClient", () => ({ getMarketStatus: jest.fn() }));
-jest.mock("../../utils/errors", () => ({ sanitizeError: jest.fn((e) => e.message) }));
-jest.mock("axios");
-jest.mock("@stellar/stellar-sdk", () => ({
-  StrKey: { isValidEd25519PublicKey: jest.fn(() => true) },
-}));
 
 const express = require("express");
 const request = require("supertest");

--- a/backend/src/routes/tests/bets.payout-concurrency.test.js
+++ b/backend/src/routes/tests/bets.payout-concurrency.test.js
@@ -1,0 +1,129 @@
+jest.mock("../../db");
+jest.mock("../../utils/redis", () => ({ get: jest.fn(), set: jest.fn(), del: jest.fn() }));
+jest.mock("../../utils/logger", () => ({
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+jest.mock("../../bots/eventBus", () => ({ emit: jest.fn() }));
+jest.mock("../../websocket/marketUpdates", () => ({ broadcastBetPlaced: jest.fn() }));
+jest.mock("../../utils/sorobanClient", () => ({ getMarketStatus: jest.fn() }));
+jest.mock("../../utils/errors", () => ({ sanitizeError: jest.fn((e) => e.message) }));
+jest.mock("axios");
+jest.mock("@stellar/stellar-sdk", () => ({
+  StrKey: { isValidEd25519PublicKey: jest.fn(() => true) },
+}));
+
+const express = require("express");
+const request = require("supertest");
+const db = require("../../db");
+const redis = require("../../utils/redis");
+const betsRouter = require("../bets");
+
+const app = express();
+app.use(express.json());
+app.use("/api/bets", betsRouter);
+
+describe("POST /api/bets/payout/:marketId concurrency safety", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    redis.del.mockResolvedValue(1);
+  });
+
+  test("concurrent payout requests pay each winner exactly once", async () => {
+    const state = {
+      market: {
+        id: 1,
+        resolved: true,
+        winning_outcome: 0,
+        total_pool: "100",
+      },
+      bets: [
+        { id: 101, market_id: 1, outcome_index: 0, wallet_address: "WALLET_A", amount: "30", paid_out: false },
+        { id: 102, market_id: 1, outcome_index: 0, wallet_address: "WALLET_B", amount: "70", paid_out: false },
+      ],
+    };
+
+    let nextClientId = 1;
+    let lockOwner = null;
+    let waiters = [];
+
+    const acquireLock = async (clientId) => {
+      if (lockOwner === null || lockOwner === clientId) {
+        lockOwner = clientId;
+        return;
+      }
+      await new Promise((resolve) => waiters.push(resolve));
+      lockOwner = clientId;
+    };
+
+    const releaseLock = (clientId) => {
+      if (lockOwner !== clientId) return;
+      lockOwner = null;
+      const next = waiters.shift();
+      if (next) next();
+    };
+
+    db.connect.mockImplementation(async () => {
+      const clientId = nextClientId++;
+      return {
+        query: jest.fn(async (sql, params = []) => {
+          if (sql === "BEGIN" || sql === "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE") {
+            return { rows: [] };
+          }
+
+          if (sql === "COMMIT" || sql === "ROLLBACK") {
+            releaseLock(clientId);
+            return { rows: [] };
+          }
+
+          if (sql.includes("FROM markets") && sql.includes("FOR UPDATE")) {
+            if (!state.market.resolved) return { rows: [] };
+            return { rows: [{ ...state.market }] };
+          }
+
+          if (sql.includes("FROM bets") && sql.includes("FOR UPDATE")) {
+            await acquireLock(clientId);
+            const marketId = Number(params[0]);
+            const outcomeIndex = Number(params[1]);
+            const rows = state.bets
+              .filter((b) => b.market_id === marketId && b.outcome_index === outcomeIndex)
+              .map((b) => ({ ...b }));
+            return { rows };
+          }
+
+          if (sql.startsWith("UPDATE bets SET paid_out = TRUE")) {
+            const ids = params[0].map(Number);
+            const updated = [];
+            for (const bet of state.bets) {
+              if (ids.includes(bet.id) && bet.paid_out === false) {
+                bet.paid_out = true;
+                updated.push({ id: bet.id, wallet_address: bet.wallet_address });
+              }
+            }
+            return { rows: updated };
+          }
+
+          throw new Error(`Unexpected query in test: ${sql}`);
+        }),
+        release: jest.fn(),
+      };
+    });
+
+    const [r1, r2] = await Promise.all([
+      request(app).post("/api/bets/payout/1").send(),
+      request(app).post("/api/bets/payout/1").send(),
+    ]);
+
+    const statuses = [r1.status, r2.status].sort((a, b) => a - b);
+    expect(statuses).toEqual([200, 400]);
+
+    const successResponse = r1.status === 200 ? r1 : r2;
+    expect(successResponse.body.payouts).toHaveLength(2);
+    expect(successResponse.body.payouts.map((p) => p.wallet).sort()).toEqual(["WALLET_A", "WALLET_B"]);
+
+    const paidCount = state.bets.filter((b) => b.paid_out).length;
+    expect(paidCount).toBe(2);
+  });
+});

--- a/backend/src/routes/tests/dev-faucet.test.js
+++ b/backend/src/routes/tests/dev-faucet.test.js
@@ -1,0 +1,82 @@
+jest.mock("../../utils/redis", () => ({
+  set: jest.fn(),
+  del: jest.fn(),
+}));
+jest.mock("axios");
+jest.mock("../../utils/logger", () => ({
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const express = require("express");
+const request = require("supertest");
+const axios = require("axios");
+const redis = require("../../utils/redis");
+const devRouter = require("../dev");
+
+const app = express();
+app.use("/api/dev", devRouter);
+
+const VALID_WALLET = "G" + "A".repeat(55);
+
+describe("GET /api/dev/faucet", () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  test("funds wallet in development and returns friendbot payload with transaction hash", async () => {
+    process.env.NODE_ENV = "development";
+    redis.set.mockResolvedValue("OK");
+    axios.get.mockResolvedValue({
+      data: {
+        hash: "tx_hash_123",
+        successful: true,
+      },
+    });
+
+    const res = await request(app).get("/api/dev/faucet").query({ wallet: VALID_WALLET });
+
+    expect(res.status).toBe(200);
+    expect(res.body.transaction_hash).toBe("tx_hash_123");
+    expect(redis.set).toHaveBeenCalledWith(
+      `faucet:wallet:${VALID_WALLET}`,
+      expect.any(String),
+      "EX",
+      3600,
+      "NX"
+    );
+    expect(axios.get).toHaveBeenCalledWith("https://friendbot.stellar.org", {
+      params: { addr: VALID_WALLET },
+    });
+  });
+
+  test("returns 403 when NODE_ENV is production", async () => {
+    process.env.NODE_ENV = "production";
+
+    const res = await request(app).get("/api/dev/faucet").query({ wallet: VALID_WALLET });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Faucet is only available in development.");
+    expect(redis.set).not.toHaveBeenCalled();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test("returns 429 when wallet is rate-limited", async () => {
+    process.env.NODE_ENV = "test";
+    redis.set.mockResolvedValue(null);
+
+    const res = await request(app).get("/api/dev/faucet").query({ wallet: VALID_WALLET });
+
+    expect(res.status).toBe(429);
+    expect(res.body.error).toMatch(/Rate limit exceeded/);
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/MarketCard.tsx
+++ b/frontend/src/components/MarketCard.tsx
@@ -25,6 +25,55 @@ interface Props {
   showFullCard?: boolean;
 }
 
+function parseNumber(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number.parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function deriveOutcomePools(market: Market, totalPool: number): number[] {
+  const outcomesCount = Math.max(market.outcomes.length, 1);
+  const equalPools = Array.from({ length: outcomesCount }, () => totalPool / outcomesCount);
+
+  if (!Array.isArray(market.outcome_pools) || market.outcome_pools.length < outcomesCount) {
+    return equalPools;
+  }
+
+  const pools = market.outcome_pools.slice(0, outcomesCount).map(parseNumber);
+  const poolSum = pools.reduce((sum, p) => sum + p, 0);
+  return poolSum > 0 ? pools : equalPools;
+}
+
+function deriveOutcomeOdds(market: Market, outcomePools: number[]): number[] {
+  const outcomesCount = Math.max(market.outcomes.length, 1);
+  const defaultOdds = Array.from({ length: outcomesCount }, () => 100 / outcomesCount);
+
+  if (Array.isArray(market.odds_bps) && market.odds_bps.length >= outcomesCount) {
+    return defaultOdds.map((fallback, i) => {
+      const bps = parseNumber(market.odds_bps?.[i]);
+      const pct = bps / 100;
+      return Number.isFinite(pct) && pct >= 0 && pct <= 100 ? pct : fallback;
+    });
+  }
+
+  if (Array.isArray(market.odds) && market.odds.length >= outcomesCount) {
+    const directOdds = market.odds.map((entry) => {
+      if (typeof entry === "number") return entry;
+      if (entry && typeof entry === "object" && "odds" in entry) return parseNumber(entry.odds);
+      return NaN;
+    });
+    if (directOdds.every((v) => Number.isFinite(v))) {
+      return directOdds.slice(0, outcomesCount).map((v, i) => (v >= 0 && v <= 100 ? v : defaultOdds[i]));
+    }
+  }
+
+  const totalFromPools = outcomePools.reduce((sum, p) => sum + p, 0);
+  if (totalFromPools > 0) {
+    return outcomePools.map((pool) => (pool / totalFromPools) * 100);
+  }
+
+  return defaultOdds;
+}
+
 export default function MarketCard({ market, walletAddress, onBetPlaced }: Props) {
   const {
     outcomeIndex: selectedOutcome,
@@ -51,18 +100,21 @@ export default function MarketCard({ market, walletAddress, onBetPlaced }: Props
   const { submitBet: submitOptimisticBet, betsForMarket } = useOptimisticBet();
   const pendingBets = betsForMarket(market.id);
   const isExpired = new Date(market.end_date) <= new Date();
-  const totalPool = parseFloat(market.total_pool);
-  const outcomePool = totalPool / market.outcomes.length;
-  
-  // Default odds for display in the ticker (until real per-outcome pool data is available)
-  const defaultOdds = 100 / market.outcomes.length;
+  const totalPool = parseNumber(market.total_pool);
+  const outcomePools = deriveOutcomePools(market, totalPool);
+  const outcomeOdds = deriveOutcomeOdds(market, outcomePools);
+  const defaultOdds = 100 / Math.max(market.outcomes.length, 1);
+  const selectedOutcomePool =
+    selectedOutcome !== null
+      ? outcomePools[selectedOutcome] ?? totalPool / Math.max(market.outcomes.length, 1)
+      : totalPool / Math.max(market.outcomes.length, 1);
 
   // Snapshot odds whenever the user selects an outcome or changes amount
   useEffect(() => {
     if (selectedOutcome !== null && amount) {
-      snapshotOdds(parseFloat(amount) || 0, outcomePool, totalPool);
+      snapshotOdds(parseFloat(amount) || 0, selectedOutcomePool, totalPool);
     }
-  }, [selectedOutcome, amount, outcomePool, totalPool, snapshotOdds]);
+  }, [selectedOutcome, amount, selectedOutcomePool, totalPool, snapshotOdds]);
 
   const handleShareMarket = async () => {
     const shareData = {
@@ -121,7 +173,7 @@ export default function MarketCard({ market, walletAddress, onBetPlaced }: Props
   async function placeBet() {
     if (selectedOutcome === null || !amount || !walletAddress) return;
 
-    const check = checkSlippage(parseFloat(amount), outcomePool, totalPool, slippageTolerance);
+    const check = checkSlippage(parseFloat(amount), selectedOutcomePool, totalPool, slippageTolerance);
     
     if (check.exceeded) {
       setSlippageWarning({ expectedPayout: check.expectedPayout, currentPayout: check.currentPayout });
@@ -192,7 +244,7 @@ export default function MarketCard({ market, walletAddress, onBetPlaced }: Props
             `}
           >
             <span>{outcome}</span>
-            <OddsTicker value={defaultOdds} size="sm" />
+            <OddsTicker value={outcomeOdds[i] ?? defaultOdds} size="sm" />
           </button>
         ))}
       </div>
@@ -229,7 +281,7 @@ export default function MarketCard({ market, walletAddress, onBetPlaced }: Props
             marketId={market.id}
             outcomeIndex={selectedOutcome}
             stakeAmount={parseFloat(amount) || 0}
-            poolForOutcome={outcomePool}
+            poolForOutcome={selectedOutcomePool}
             totalPool={totalPool}
           />
         </div>
@@ -246,7 +298,7 @@ export default function MarketCard({ market, walletAddress, onBetPlaced }: Props
       )}
 
       {!market.resolved && !isExpired && selectedOutcome !== null && (
-        <WhatIfSimulator poolForOutcome={outcomePool} totalPool={totalPool} />
+        <WhatIfSimulator poolForOutcome={selectedOutcomePool} totalPool={totalPool} />
       )}
 
       <ResolutionCenter market={market} compact />

--- a/frontend/src/hooks/__tests__/useMarkets.test.ts
+++ b/frontend/src/hooks/__tests__/useMarkets.test.ts
@@ -196,7 +196,7 @@ describe("usePlaceBet", () => {
     );
   });
 
-  it("invalidates markets and market queries on success", async () => {
+  it("invalidates markets, market detail, and market stats queries on success", async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ bet: { id: 10 } }),
@@ -216,6 +216,7 @@ describe("usePlaceBet", () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["markets"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["market", "1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["market", "1", "stats"] });
   });
 
   it("sets isError on API failure", async () => {

--- a/frontend/src/hooks/usePlaceBet.ts
+++ b/frontend/src/hooks/usePlaceBet.ts
@@ -28,6 +28,7 @@ export function usePlaceBet(marketId?: number) {
       queryClient.invalidateQueries({ queryKey: ["markets"] });
       if (marketId !== undefined) {
         queryClient.invalidateQueries({ queryKey: ["market", String(marketId)] });
+        queryClient.invalidateQueries({ queryKey: ["market", String(marketId), "stats"] });
       }
     },
   });

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -5,6 +5,16 @@ export interface ResolutionSource {
 
 export type ResolutionState = "closed" | "proposed" | "disputed" | "settled";
 
+export interface MarketOddsEntry {
+  index: number;
+  odds: number;
+}
+
+export interface MarketAsset {
+  code: string;
+  issuer: string;
+}
+
 export interface Market {
   id: number;
   question: string;
@@ -22,5 +32,8 @@ export interface Market {
   resolution_state?: ResolutionState;
   resolution_notes?: string | null;
   resolution_sources?: ResolutionSource[];
-  asset?: { code: string; issuer: string };
+  asset?: MarketAsset;
+  outcome_pools?: Array<number | string>;
+  odds_bps?: Array<number | string>;
+  odds?: Array<number | MarketOddsEntry>;
 }

--- a/oracle/index.js
+++ b/oracle/index.js
@@ -5,6 +5,14 @@ const { btcSources } = require("./sources");
 
 const API_URL = process.env.API_URL || "http://localhost:4000";
 
+// ── Logger ────────────────────────────────────────────────────────────────────
+const logger = {
+  info:  (...a) => console.log(...a),
+  warn:  (...a) => console.warn(...a),
+  error: (...a) => console.error(...a),
+  debug: (...a) => process.env.LOG_LEVEL === "debug" && console.debug(...a),
+};
+
 // ── DB connection for audit logging ──────────────────────────────────────────
 // Lazy-require so the oracle can run without a DB in test environments.
 // The DB pool is only used for audit logging — resolution still works without it.
@@ -23,10 +31,15 @@ function getDb() {
 
 // ── Graceful Shutdown State ───────────────────────────────────────────────────
 
+const INTERVAL_NORMAL = 60 * 1000;       // 60 seconds
+const INTERVAL_BACKOFF = 5 * 60 * 1000;  // 5 minutes
+const BACKOFF_THRESHOLD = 3;             // consecutive empty runs before backoff
+
 let intervalHandle = null;
 let isRunning = false;
 let isShuttingDown = false;
 let currentRunPromise = Promise.resolve();
+let consecutiveEmptyRuns = 0;
 
 /**
  * Fetch all unresolved, expired markets and resolve them
@@ -34,13 +47,13 @@ let currentRunPromise = Promise.resolve();
 async function runOracle() {
   // Prevent concurrent oracle runs
   if (isRunning) {
-    console.log("[Oracle] Oracle is already running, skipping this cycle");
+    logger.info("[Oracle] Oracle is already running, skipping this cycle");
     return;
   }
 
   isRunning = true;
   try {
-    console.log("[Oracle] Checking for markets to resolve...");
+    logger.info("[Oracle] Checking for markets to resolve...");
     const { data } = await axios.get(`${API_URL}/api/markets`);
     const now = Date.now();
     // #377: Add 60-second buffer to account for clock drift
@@ -50,44 +63,139 @@ async function runOracle() {
       (m) => !m.resolved && new Date(m.end_date).getTime() <= now - bufferMs
     );
 
-    console.log(`[Oracle] Found ${expired.length} market(s) to resolve`);
+    // #440: Early exit when there is nothing to do
+    if (expired.length === 0) {
+      logger.debug("[Oracle] No expired markets to resolve");
+      consecutiveEmptyRuns++;
+      if (consecutiveEmptyRuns >= BACKOFF_THRESHOLD) {
+        reschedule(INTERVAL_BACKOFF);
+      }
+      return;
+    }
+
+    // Reset backoff — we have real work to do
+    consecutiveEmptyRuns = 0;
+    reschedule(INTERVAL_NORMAL);
+
+    logger.debug(`[Oracle] Found ${expired.length} market(s) to resolve`);
 
     for (const market of expired) {
       // Check if shutdown was requested during resolution
       if (isShuttingDown) {
-        console.log("[Oracle] Shutdown requested, stopping market resolution");
+        logger.info("[Oracle] Shutdown requested, stopping market resolution");
         break;
       }
       await resolveMarket(market);
     }
   } catch (err) {
-    console.error("[Oracle] Error:", err.message);
+    logger.error("[Oracle] Error:", err.message);
   } finally {
     isRunning = false;
   }
 }
 
+const TRANSIENT_PATTERNS = [/tx_too_late/i, /timeout/i];
+const MAX_TRANSIENT_ATTEMPTS = 3;
+const TRANSIENT_RETRY_DELAY_MS = 5 * 1000;
+
 async function resolveMarket(market) {
-  console.log(`[Oracle] Resolving market #${market.id}: "${market.question}"`);
+  logger.info(`[Oracle] Resolving market #${market.id}: "${market.question}"`);
+  let winningOutcome;
   try {
-    const winningOutcome = await fetchOutcome(market.question, market.outcomes);
-    await axios.post(`${API_URL}/api/markets/${market.id}/resolve`, { winningOutcome });
-    console.log(`[Oracle] Market #${market.id} resolved → outcome index: ${winningOutcome}`);
+    winningOutcome = await fetchOutcome(market.question, market.outcomes);
   } catch (err) {
-    // #377: Handle deadline not reached errors gracefully
-    if (err.response?.data?.error?.includes("Market deadline not reached")) {
-      console.warn(`[Oracle] Market #${market.id} deadline not reached on-chain, retrying in 5 minutes`);
-      // Add to retry queue (in production, use persistent queue)
-      const retryTime = new Date(Date.now() + 5 * 60 * 1000);
-      console.log(`[Oracle] Market #${market.id} scheduled for retry at ${retryTime.toISOString()}`);
-      return;
-    }
     if (err.message && err.message.startsWith("No resolver matched")) {
-      console.error(`[Oracle] Unresolvable market #${market.id}: ${err.message}`);
+      logger.error(`[Oracle] Unresolvable market #${market.id}: ${err.message}`);
       await markUnresolvable(market.id, market.question, err.message);
     } else {
-      console.error(`[Oracle] Failed to resolve market #${market.id}:`, err.message);
+      logger.error(`[Oracle] Failed to resolve market #${market.id}:`, err.message);
     }
+    return;
+  }
+
+  await resolveWithRetry(market, winningOutcome);
+}
+
+function classifyErrorMessage(message) {
+  if (!message) return "PERMANENT";
+  if (TRANSIENT_PATTERNS.some((pattern) => pattern.test(message))) {
+    return "TRANSIENT";
+  }
+  return "PERMANENT";
+}
+
+function extractErrorMessage(err) {
+  return (
+    err.response?.data?.error ??
+    err.response?.data?.message ??
+    err.message ??
+    "Unknown error"
+  );
+}
+
+
+const defaultDelayExecutor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+let delayExecutor = defaultDelayExecutor;
+
+function delay(ms) {
+  return delayExecutor(ms);
+}
+
+function _setDelayExecutor(fn) {
+  delayExecutor = fn;
+}
+
+function _resetDelayExecutor() {
+  delayExecutor = defaultDelayExecutor;
+}
+
+async function resolveWithRetry(market, winningOutcome) {
+  let attempt = 0;
+  let lastError = null;
+
+  while (attempt < MAX_TRANSIENT_ATTEMPTS) {
+    attempt++;
+    try {
+      await axios.post(`${API_URL}/api/markets/${market.id}/resolve`, { winningOutcome });
+      logger.info(`[Oracle] Market #${market.id} resolved → outcome index: ${winningOutcome}`);
+      return;
+    } catch (err) {
+      lastError = err;
+      const message = extractErrorMessage(err);
+      const classification = classifyErrorMessage(message);
+      logger.info(
+        `[Oracle] Market #${market.id} attempt ${attempt} classified as ${classification}: ${message}`
+      );
+
+      if (message.includes("Market deadline not reached")) {
+        logger.warn(
+          `[Oracle] Market #${market.id} deadline not reached on-chain, retrying in 5 minutes`
+        );
+        const retryTime = new Date(Date.now() + 5 * 60 * 1000);
+        logger.info(`[Oracle] Market #${market.id} scheduled for retry at ${retryTime.toISOString()}`);
+        return;
+      }
+
+      if (classification === "TRANSIENT" && attempt < MAX_TRANSIENT_ATTEMPTS) {
+        await delay(TRANSIENT_RETRY_DELAY_MS);
+        continue;
+      }
+
+      await handlePermanentResolutionFailure(market, message, err);
+      return;
+    }
+  }
+
+  if (lastError) {
+    const message = extractErrorMessage(lastError);
+    await handlePermanentResolutionFailure(market, message, lastError);
+  }
+}
+
+async function handlePermanentResolutionFailure(market, message, err) {
+  logger.error(`[Oracle] Failed to resolve market #${market.id}:`, message);
+  if (err.message && err.message.startsWith("No resolver matched")) {
+    await markUnresolvable(market.id, market.question, err.message);
   }
 }
 
@@ -98,7 +206,7 @@ async function markUnresolvable(marketId, question, reason) {
       question,
       error_message: reason 
     });
-    console.warn(`[Oracle] Market #${marketId} marked for pending review: ${reason}`);
+    logger.warn(`[Oracle] Market #${marketId} marked for pending review: ${reason}`);
     
     // Send webhook alert if configured
     const webhookUrl = process.env.ADMIN_ALERT_WEBHOOK_URL;
@@ -112,11 +220,11 @@ async function markUnresolvable(marketId, question, reason) {
           timestamp: new Date().toISOString()
         });
       } catch (webhookErr) {
-        console.error(`[Oracle] Failed to send webhook alert:`, webhookErr.message);
+        logger.error(`[Oracle] Failed to send webhook alert:`, webhookErr.message);
       }
     }
   } catch (err) {
-    console.error(`[Oracle] Failed to mark market #${marketId} as pending review:`, err.message);
+    logger.error(`[Oracle] Failed to mark market #${marketId} as pending review:`, err.message);
   }
 }
 
@@ -146,7 +254,7 @@ async function resolveCryptoPrice(question, outcomes) {
     // DB is injected for audit logging — null in test environments.
     const medianizer = new OracleMedianizer(btcSources, console, getDb());
     const btcPrice = await medianizer.aggregate("BTC/USD");
-    console.log(`[Oracle] BTC median price: ${btcPrice}`);
+    logger.info(`[Oracle] BTC median price: ${btcPrice}`);
 
     if (question.toLowerCase().includes("100k") || question.includes("100,000")) {
       return btcPrice >= 100000 ? 0 : 1;
@@ -155,18 +263,32 @@ async function resolveCryptoPrice(question, outcomes) {
   } catch (err) {
     // Insufficient sources (< 2 valid) — push to pending review
     if (err.message.includes("Insufficient valid sources") || err.message.includes("Too many outliers")) {
-      console.error(`[Oracle] Crypto price aggregation failed — pushing to pending review: ${err.message}`);
+      logger.error(`[Oracle] Crypto price aggregation failed — pushing to pending review: ${err.message}`);
       throw err; // bubble up so resolveMarket calls markUnresolvable
     }
-    console.error("[Oracle] Crypto price aggregation failed:", err.message);
+    logger.error("[Oracle] Crypto price aggregation failed:", err.message);
     throw err;
   }
 }
 
 async function resolveFinancial(question, outcomes) {
   // Placeholder — integrate with a financial data API (e.g. ExchangeRate-API)
-  console.warn("[Oracle] Financial resolver not yet integrated — defaulting to outcome 0");
+  logger.warn("[Oracle] Financial resolver not yet integrated — defaulting to outcome 0");
   return 0;
+}
+
+// ── Adaptive polling (#440) ───────────────────────────────────────────────────
+
+/**
+ * Replace the running interval with a new one at the given delay.
+ * No-op if the delay matches the current interval or if shutting down.
+ */
+function reschedule(newInterval) {
+  if (isShuttingDown) return;
+  if (intervalHandle !== null) clearInterval(intervalHandle);
+  intervalHandle = setInterval(() => {
+    currentRunPromise = runOracleGuarded();
+  }, newInterval);
 }
 
 // ── Graceful shutdown (#374) ──────────────────────────────────────────────────
@@ -176,25 +298,25 @@ async function resolveFinancial(question, outcomes) {
  * Stops the interval, waits for in-flight resolutions to complete, then exits
  */
 async function gracefulShutdown(signal) {
-  console.log(`[Oracle] ${signal} received — Oracle shutting down gracefully`);
+  logger.info(`[Oracle] ${signal} received — Oracle shutting down gracefully`);
   
   isShuttingDown = true;
   
   // Stop scheduling new resolution cycles
   if (intervalHandle !== null) {
     clearInterval(intervalHandle);
-    console.log("[Oracle] Interval cleared, no new resolution cycles will start");
+    logger.info("[Oracle] Interval cleared, no new resolution cycles will start");
   }
   
   // Wait for any in-flight resolution to complete
   try {
     await currentRunPromise;
-    console.log("[Oracle] In-flight resolutions completed");
+    logger.info("[Oracle] In-flight resolutions completed");
   } catch (err) {
-    console.error("[Oracle] Error waiting for in-flight resolutions:", err.message);
+    logger.error("[Oracle] Error waiting for in-flight resolutions:", err.message);
   }
   
-  console.log("[Oracle] Graceful shutdown complete");
+  logger.info("[Oracle] Graceful shutdown complete");
   process.exit(0);
 }
 
@@ -203,7 +325,7 @@ async function gracefulShutdown(signal) {
  */
 async function runOracleGuarded() {
   if (isRunning) {
-    console.warn("[Oracle] Skipping run — previous cycle still in progress");
+    logger.warn("[Oracle] Skipping run — previous cycle still in progress");
     return;
   }
   
@@ -215,19 +337,15 @@ async function runOracleGuarded() {
   }
 }
 
-// Register signal handlers for graceful shutdown
-process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
-process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+// Only start the interval when run directly (not when require'd by tests)
+if (require.main === module) {
+  process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+  process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 
-// Start the oracle interval
-intervalHandle = setInterval(() => {
+  reschedule(INTERVAL_NORMAL);
   currentRunPromise = runOracleGuarded();
-}, 60 * 1000);
-
-// Kick off first run immediately
-currentRunPromise = runOracleGuarded();
-
-console.log("[Oracle] Started with 60-second resolution cycle");
+  logger.info("[Oracle] Started with 60-second resolution cycle");
+}
 
 // Exported for unit tests only
 module.exports = {
@@ -237,7 +355,23 @@ module.exports = {
   fetchOutcome,
   markUnresolvable,
   gracefulShutdown,
+  reschedule,
   _getIsRunning: () => isRunning,
   _getIsShuttingDown: () => isShuttingDown,
   _getIntervalHandle: () => intervalHandle,
+  _getConsecutiveEmptyRuns: () => consecutiveEmptyRuns,
+  _resetState: () => {
+    consecutiveEmptyRuns = 0;
+    isRunning = false;
+    isShuttingDown = false;
+    if (intervalHandle !== null) { clearInterval(intervalHandle); intervalHandle = null; }
+  },
+  INTERVAL_NORMAL,
+  INTERVAL_BACKOFF,
+  BACKOFF_THRESHOLD,
+  TRANSIENT_RETRY_DELAY_MS,
+  MAX_TRANSIENT_ATTEMPTS,
+  delay,
+  _setDelayExecutor,
+  _resetDelayExecutor,
 };

--- a/oracle/index.test.js
+++ b/oracle/index.test.js
@@ -1,64 +1,84 @@
-const axios = require("axios");
-const { fetchOutcome, markUnresolvable, shutdown, _getIsRunning } = require("./index");
-
 jest.mock("axios");
+jest.mock("./medianizer", () => ({
+  OracleMedianizer: jest.fn().mockImplementation(() => ({
+    aggregate: jest.fn().mockResolvedValue(95000),
+  })),
+}));
+
+jest.setTimeout(20000);
+
+const axios = require("axios");
+
+// Shared module — reset state before each test to prevent bleed
+let oracle;
+beforeEach(() => {
+  oracle = require("./index");
+  oracle._resetState();
+  jest.clearAllMocks();
+});
+
+// ── Pre-existing suites ───────────────────────────────────────────────────────
 
 describe("Oracle Graceful Shutdown (#223)", () => {
-  test("shutdown logs graceful message", () => {
+  test("gracefulShutdown logs graceful message", async () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation();
     const exitSpy = jest.spyOn(process, "exit").mockImplementation();
-    
-    shutdown("SIGTERM");
-    
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Oracle shutting down gracefully"));
-    
+
+    await oracle.gracefulShutdown("SIGTERM");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Oracle shutting down gracefully")
+    );
+
     logSpy.mockRestore();
     exitSpy.mockRestore();
   });
 
   test("concurrent runs are prevented by isRunning flag", async () => {
+    // Make runOracle hang so the second call sees isRunning=true
+    axios.get.mockImplementation(() => new Promise(() => {}));
     const warnSpy = jest.spyOn(console, "warn").mockImplementation();
-    const { runOracleGuarded } = require("./index");
-    
-    // Simulate concurrent call
-    const promise1 = runOracleGuarded();
-    const promise2 = runOracleGuarded();
-    
-    await Promise.all([promise1, promise2]);
-    
-    // Second call should be skipped
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("previous cycle still in progress"));
-    
+
+    const p1 = oracle.runOracleGuarded();
+    const p2 = oracle.runOracleGuarded(); // should be skipped
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("previous cycle still in progress")
+    );
+
     warnSpy.mockRestore();
+    // Don't await p1 — it hangs intentionally; jest forceExit handles cleanup
   });
 });
 
 describe("Oracle Default Outcome (#218)", () => {
   test("fetchOutcome throws when no resolver matches", async () => {
-    await expect(fetchOutcome("Who will win the 2025 Ballon d'Or?", ["Messi", "Ronaldo"]))
-      .rejects
-      .toThrow("No resolver matched");
+    await expect(
+      oracle.fetchOutcome("Who will win the 2025 Ballon d'Or?", ["Messi", "Ronaldo"])
+    ).rejects.toThrow("No resolver matched");
   });
 
-  test("markUnresolvable calls backend endpoint", async () => {
+  test("markUnresolvable calls backend pending-review endpoint", async () => {
     axios.post.mockResolvedValue({ data: { success: true } });
-    
-    await markUnresolvable(123, "No resolver matched");
-    
+
+    await oracle.markUnresolvable(123, "some question", "No resolver matched");
+
     expect(axios.post).toHaveBeenCalledWith(
-      expect.stringContaining("/api/markets/123/unresolvable"),
-      { reason: "No resolver matched" }
+      expect.stringContaining("/api/admin/pending-review"),
+      expect.objectContaining({ market_id: 123, error_message: "No resolver matched" })
     );
   });
 
   test("markUnresolvable logs warning on success", async () => {
     axios.post.mockResolvedValue({ data: {} });
     const warnSpy = jest.spyOn(console, "warn").mockImplementation();
-    
-    await markUnresolvable(456, "test reason");
-    
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("marked unresolvable"));
-    
+
+    await oracle.markUnresolvable(456, "some question", "test reason");
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("marked for pending review")
+    );
+
     warnSpy.mockRestore();
   });
 });
@@ -66,70 +86,256 @@ describe("Oracle Default Outcome (#218)", () => {
 describe("Oracle Deadline Verification (#377)", () => {
   test("markets within 60-second buffer are not resolved", async () => {
     const now = Date.now();
-    const market = {
-      id: 1,
-      question: "Test market",
-      end_date: new Date(now + 30_000).toISOString(), // 30 seconds in future
-      resolved: false,
-      outcomes: ["Yes", "No"]
-    };
+    axios.get.mockResolvedValue({
+      data: {
+        markets: [
+          {
+            id: 1,
+            question: "Test market",
+            end_date: new Date(now + 30_000).toISOString(),
+            resolved: false,
+            outcomes: ["Yes", "No"],
+          },
+        ],
+      },
+    });
 
-    axios.get.mockResolvedValue({ data: { markets: [market] } });
-    const logSpy = jest.spyOn(console, "log").mockImplementation();
+    await oracle.runOracle();
 
-    const { runOracle } = require("./index");
-    await runOracle();
-
-    // Market should not be in the expired list due to 60-second buffer
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Found 0 market(s) to resolve"));
-
-    logSpy.mockRestore();
+    expect(axios.post).not.toHaveBeenCalled();
   });
 
   test("markets past 60-second buffer are resolved", async () => {
     const now = Date.now();
-    const market = {
-      id: 1,
-      question: "Test market",
-      end_date: new Date(now - 70_000).toISOString(), // 70 seconds in past
-      resolved: false,
-      outcomes: ["Yes", "No"]
-    };
-
-    axios.get.mockResolvedValue({ data: { markets: [market] } });
+    axios.get.mockResolvedValue({
+      data: {
+        markets: [
+          {
+            id: 1,
+            question: "BTC above 100k?",
+            end_date: new Date(now - 70_000).toISOString(),
+            resolved: false,
+            outcomes: ["Yes", "No"],
+          },
+        ],
+      },
+    });
+    // Mock the resolve POST to succeed
     axios.post.mockResolvedValue({ data: { success: true } });
     const logSpy = jest.spyOn(console, "log").mockImplementation();
 
-    const { runOracle } = require("./index");
-    await runOracle();
+    await oracle.runOracle();
 
-    // Market should be in the expired list
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Found 1 market(s) to resolve"));
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Market #1 resolved")
+    );
 
     logSpy.mockRestore();
   });
 
-  test("deadline not reached errors are logged as warnings and retried", async () => {
+  test("deadline not reached errors are logged as warnings", async () => {
     const market = {
       id: 1,
-      question: "Test market",
+      question: "BTC above 100k?",
       end_date: new Date(Date.now() - 70_000).toISOString(),
       resolved: false,
-      outcomes: ["Yes", "No"]
+      outcomes: ["Yes", "No"],
     };
-
     axios.get.mockResolvedValue({ data: { markets: [market] } });
     axios.post.mockRejectedValue({
-      response: { data: { error: "Market deadline not reached" } }
+      response: { data: { error: "Market deadline not reached" } },
     });
     const warnSpy = jest.spyOn(console, "warn").mockImplementation();
 
-    const { runOracle } = require("./index");
-    await runOracle();
+    await oracle.runOracle();
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("deadline not reached on-chain"));
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("retrying in 5 minutes"));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("deadline not reached on-chain")
+    );
 
     warnSpy.mockRestore();
+  });
+});
+
+// ── Adaptive Polling (#440) ───────────────────────────────────────────────────
+
+describe("Oracle Adaptive Polling (#440)", () => {
+  function mockEmpty() {
+    axios.get.mockResolvedValue({ data: { markets: [] } });
+  }
+
+  function mockExpired() {
+    const now = Date.now();
+    axios.get.mockResolvedValue({
+      data: {
+        markets: [
+          {
+            id: 2,
+            question: "BTC above 100k?",
+            end_date: new Date(now - 70_000).toISOString(),
+            resolved: false,
+            outcomes: ["Yes", "No"],
+          },
+        ],
+      },
+    });
+    axios.post.mockResolvedValue({ data: { success: true } });
+  }
+
+  test("returns early with debug log when markets array is empty", async () => {
+    mockEmpty();
+    const debugSpy = jest.spyOn(console, "debug").mockImplementation();
+    const saved = process.env.LOG_LEVEL;
+    process.env.LOG_LEVEL = "debug";
+
+    await oracle.runOracle();
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No expired markets to resolve")
+    );
+
+    process.env.LOG_LEVEL = saved;
+    debugSpy.mockRestore();
+  });
+
+  test("returns early without calling resolve when no expired markets", async () => {
+    const now = Date.now();
+    axios.get.mockResolvedValue({
+      data: {
+        markets: [
+          {
+            id: 1,
+            question: "Q",
+            end_date: new Date(now + 30_000).toISOString(),
+            resolved: false,
+            outcomes: ["Yes", "No"],
+          },
+        ],
+      },
+    });
+
+    await oracle.runOracle();
+
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  test("consecutiveEmptyRuns increments on each empty run", async () => {
+    mockEmpty();
+
+    await oracle.runOracle();
+    expect(oracle._getConsecutiveEmptyRuns()).toBe(1);
+
+    await oracle.runOracle();
+    expect(oracle._getConsecutiveEmptyRuns()).toBe(2);
+  });
+
+  test("interval handle is replaced after 3 consecutive empty runs", async () => {
+    jest.useFakeTimers();
+    mockEmpty();
+
+    const handleBefore = oracle._getIntervalHandle();
+
+    await oracle.runOracle(); // 1
+    await oracle.runOracle(); // 2
+    await oracle.runOracle(); // 3 — triggers backoff reschedule
+
+    const handleAfter = oracle._getIntervalHandle();
+    // A new interval was created (different reference or null→set)
+    expect(handleAfter).not.toBe(handleBefore);
+
+    jest.useRealTimers();
+  });
+
+  test("consecutiveEmptyRuns resets to 0 when a market is found", async () => {
+    mockEmpty();
+    await oracle.runOracle();
+    await oracle.runOracle();
+    await oracle.runOracle(); // enter backoff
+
+    mockExpired();
+    await oracle.runOracle();
+
+    expect(oracle._getConsecutiveEmptyRuns()).toBe(0);
+  });
+
+  test("no backoff before threshold: consecutiveEmptyRuns stays below 3", async () => {
+    mockEmpty();
+
+    await oracle.runOracle(); // 1
+    await oracle.runOracle(); // 2
+
+    expect(oracle._getConsecutiveEmptyRuns()).toBe(2);
+    // Backoff threshold not yet reached
+    expect(oracle._getConsecutiveEmptyRuns()).toBeLessThan(oracle.BACKOFF_THRESHOLD);
+  });
+});
+
+describe("Oracle Resolve Retry (#490)", () => {
+  const market = {
+    id: 99,
+    question: "BTC > 100k?",
+    end_date: new Date(Date.now() - 70_000).toISOString(),
+    resolved: false,
+    outcomes: ["Yes", "No"],
+  };
+
+  test("tx_too_late triggers transient retries until success", async () => {
+    let attempt = 0;
+    axios.post.mockImplementation(() => {
+      attempt++;
+      if (attempt < 3) {
+        return Promise.reject({ response: { data: { error: "tx_too_late" } } });
+      }
+      return Promise.resolve({ data: { success: true } });
+    });
+
+    const infoSpy = jest.spyOn(console, "log").mockImplementation();
+    oracle._setDelayExecutor(() => Promise.resolve());
+
+    await oracle.resolveMarket(market);
+
+    expect(axios.post).toHaveBeenCalledTimes(3);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("classified as TRANSIENT")
+    );
+
+    oracle._resetDelayExecutor();
+    infoSpy.mockRestore();
+  });
+
+  test("permanent errors are not retried", async () => {
+    axios.post.mockRejectedValue({
+      response: { data: { error: "Invalid outcome" } },
+    });
+    const errorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    await oracle.resolveMarket(market);
+
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to resolve market"),
+      "Invalid outcome"
+    );
+
+    errorSpy.mockRestore();
+  });
+
+  test("transient errors exhaust retries before failing permanently", async () => {
+    axios.post.mockRejectedValue({
+      response: { data: { error: "tx_too_late" } },
+    });
+    const errorSpy = jest.spyOn(console, "error").mockImplementation();
+    oracle._setDelayExecutor(() => Promise.resolve());
+
+    await oracle.resolveMarket(market);
+
+    expect(axios.post).toHaveBeenCalledTimes(3);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to resolve market"),
+      "tx_too_late"
+    );
+
+    oracle._resetDelayExecutor();
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Fixes **#491** by invalidating all relevant React Query caches after bet placement: `['markets']`, `['market', marketId]`, and `['market', marketId, 'stats']`.
- Fixes **#491** UI behavior by rendering market-card odds from live market pool/odds fields and showing visible odds change flash through `OddsTicker`.
- Fixes **#492** by making payout processing concurrency-safe with a PostgreSQL `SERIALIZABLE` transaction and `SELECT ... FOR UPDATE` row locking on market and winning bets.
- Fixes **#492** correctness by re-checking `paid_out` in-transaction, skipping already-paid rows, and updating only unlocked unpaid winner rows atomically.
- Fixes **#495** by adding a development-only faucet endpoint: `GET /api/dev/faucet?wallet=ADDRESS`, guarded by `NODE_ENV`, integrated with Friendbot, and rate-limited to one request per wallet per hour via Redis.
- Fixes **#490** by classifying oracle resolve errors into transient vs permanent, retrying transient (`tx_too_late`, `timeout`) failures up to 3 attempts with 5-second delay, and logging classification + retry count.

## Validation
- `npm --workspace backend test -- src/routes/tests/dev-faucet.test.js src/routes/tests/bets.payout-concurrency.test.js`
- `npx --workspace frontend jest --config jest.config.js src/hooks/__tests__/useMarkets.test.ts src/components/__tests__/OddsTicker.test.tsx --runInBand --coverage=false --silent`
- `npx --workspace oracle jest --coverage=false oracle/index.test.js --runInBand --testNamePattern "Resolve Retry"`

## Issue Links
Closes #491
Closes #492
Closes #495
Closes #490
