### PR TITLE
fix: sanitize market questions and add CSP to prevent stored XSS (#590)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "prom-client": "^15.1.3",
-    "sanitize-html": "^2.17.0",
+    "sanitize-html": "^2.17.2",
     "ws": "^8.20.0"
   },
   "devDependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "prom-client": "^15.1.3",
+    "sanitize-html": "^2.17.0",
     "ws": "^8.20.0"
   },
   "devDependencies": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -68,6 +68,7 @@ app.use((req, res, next) => {
     const duration = Date.now() - start;
     logger.info(
       {
+        request_id: req.requestId,
         method: req.method,
         path: req.path,
         status: res.statusCode,

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -52,8 +52,14 @@ app.use(
 
 app.use(express.json());
 
+// Mitigate impact of any HTML echoed by clients: enforce baseline CSP on every response.
+app.use((req, res, next) => {
+  res.setHeader("Content-Security-Policy", "default-src 'self'");
+  next();
+});
+
 // Request tracking and logging middleware
-app.use((req, res, _next) => {
+app.use((req, res, next) => {
   req.requestId = req.headers["x-request-id"] || crypto.randomUUID();
   res.setHeader("X-Request-ID", req.requestId);
 
@@ -72,7 +78,7 @@ app.use((req, res, _next) => {
       "HTTP Request"
     );
   });
-  _next();
+  next();
 });
 
 // Health and readiness probes — NOT behind App Check so orchestrators can probe freely

--- a/backend/src/routes/markets.js
+++ b/backend/src/routes/markets.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const sanitizeHtml = require("sanitize-html");
 const router = express.Router();
 const db = require("../db");
 const { triggerNotification } = require("../utils/notifications");
@@ -126,14 +127,19 @@ router.get("/", async (req, res) => {
 router.post("/", validateMarketCreation, rateLimitMarketCreation, async (req, res) => {
   const { question, endDate, outcomes, contractAddress, walletAddress, categoryId } = req.body;
 
+  const sanitizedQuestion =
+    typeof question === "string"
+      ? sanitizeHtml(question, { allowedTags: [], allowedAttributes: {} }).trim()
+      : "";
+
   // Basic required field validation (middleware handles detailed validation)
-  if (!question || !endDate || !outcomes?.length || !walletAddress || !categoryId) {
+  if (!sanitizedQuestion || !endDate || !outcomes?.length || !walletAddress || !categoryId) {
     return res.status(400).json({
       error: {
         code: "MISSING_REQUIRED_FIELDS",
         message: "question, endDate, outcomes, walletAddress, and categoryId are required",
         details: {
-          question: !!question,
+          question: !!sanitizedQuestion,
           endDate: !!endDate,
           outcomes: !!outcomes?.length,
           walletAddress: !!walletAddress,
@@ -149,13 +155,13 @@ router.post("/", validateMarketCreation, rateLimitMarketCreation, async (req, re
     // Market has passed all validation checks - create immediately without admin approval
     const result = await db.query(
       "INSERT INTO markets (question, end_date, outcomes, contract_address, category_id, fee_rate_bps, created_at) VALUES ($1, $2, $3, $4, $5, $6, NOW()) RETURNING *",
-      [question, endDate, outcomes, contractAddress || null, categoryId, feeRateBps]
+      [sanitizedQuestion, endDate, outcomes, contractAddress || null, categoryId, feeRateBps]
     );
 
     logger.info(
       {
         market_id: result.rows[0].id,
-        question,
+        question: sanitizedQuestion,
         wallet_address: walletAddress,
         contract_address: contractAddress,
         outcomes_count: outcomes.length,
@@ -176,20 +182,12 @@ router.post("/", validateMarketCreation, rateLimitMarketCreation, async (req, re
     // Emit market.created so registered bot strategies can seed initial liquidity
     eventBus.emit("market.created", {
       marketId: result.rows[0].id,
-      question,
-      outcomes: outcomes ?? [],
-      totalPool: 0,
-    });
-
-    // Emit market.created so registered bot strategies can seed initial liquidity
-    eventBus.emit("market.created", {
-      marketId: result.rows[0].id,
-      question,
+      question: sanitizedQuestion,
       outcomes: outcomes ?? [],
       totalPool: 0,
     });
   } catch (err) {
-    logger.error({ err, question, wallet_address: walletAddress }, "Failed to create market");
+    logger.error({ err, question: sanitizedQuestion, wallet_address: walletAddress }, "Failed to create market");
     res.status(500).json({
       error: {
         code: "DATABASE_ERROR",

--- a/backend/src/routes/markets.js
+++ b/backend/src/routes/markets.js
@@ -133,7 +133,15 @@ router.post("/", validateMarketCreation, rateLimitMarketCreation, async (req, re
       : "";
 
   // Basic required field validation (middleware handles detailed validation)
-  if (!sanitizedQuestion || !endDate || !outcomes?.length || !walletAddress || !categoryId) {
+  if (
+    !sanitizedQuestion ||
+    !endDate ||
+    !outcomes?.length ||
+    !walletAddress ||
+    categoryId === undefined ||
+    categoryId === null
+  ) {
+
     return res.status(400).json({
       error: {
         code: "MISSING_REQUIRED_FIELDS",
@@ -143,7 +151,7 @@ router.post("/", validateMarketCreation, rateLimitMarketCreation, async (req, re
           endDate: !!endDate,
           outcomes: !!outcomes?.length,
           walletAddress: !!walletAddress,
-          categoryId: !!categoryId,
+          categoryId: categoryId !== undefined && categoryId !== null,
         },
       },
     });

--- a/backend/src/tests/markets-xss.test.js
+++ b/backend/src/tests/markets-xss.test.js
@@ -1,0 +1,102 @@
+/**
+ * POST /api/markets — ensure market question is sanitized before storage (stored XSS).
+ */
+
+const request = require("supertest");
+const express = require("express");
+const sanitizeHtml = require("sanitize-html");
+
+jest.mock("../middleware/marketValidation", () => ({
+  validateMarketCreation: (req, res, next) => next(),
+  rateLimitMarketCreation: (req, res, next) => next(),
+}));
+
+jest.mock("../db");
+
+jest.mock("../bots/eventBus", () => ({
+  emit: jest.fn(),
+}));
+
+jest.mock("../utils/redis", () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const db = require("../db");
+const eventBus = require("../bots/eventBus");
+const marketsRouter = require("../routes/markets");
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    res.setHeader("Content-Security-Policy", "default-src 'self'");
+    next();
+  });
+  app.use("/api/markets", marketsRouter);
+  return app;
+}
+
+describe("POST /api/markets — question XSS sanitization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("strips script tags and HTML from question before database insert", async () => {
+    const endDate = new Date(Date.now() + 86400000).toISOString();
+    const plainSuffix =
+      " Will Bitcoin reach one hundred thousand dollars by end of 2026? Extra text for min length.";
+    const malicious = `<script>alert('xss')</script><img src=x onerror=alert(1)>${plainSuffix}`;
+
+    const expectedStored = sanitizeHtml(malicious, {
+      allowedTags: [],
+      allowedAttributes: {},
+    }).trim();
+
+    expect(expectedStored).not.toMatch(/<script/i);
+    expect(expectedStored).not.toMatch(/onerror/i);
+
+    const inserted = {
+      id: 42,
+      question: expectedStored,
+      end_date: endDate,
+      outcomes: ["Yes", "No"],
+      contract_address: null,
+      created_at: new Date().toISOString(),
+    };
+
+    db.query.mockResolvedValueOnce({ rows: [inserted] });
+
+    const app = buildApp();
+    const res = await request(app)
+      .post("/api/markets")
+      .send({
+        question: malicious,
+        endDate,
+        outcomes: ["Yes", "No"],
+        walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.headers["content-security-policy"]).toBe("default-src 'self'");
+    expect(res.body.market.question).toBe(expectedStored);
+
+    const insertCall = db.query.mock.calls.find((c) =>
+      String(c[0]).includes("INSERT INTO markets")
+    );
+    expect(insertCall).toBeDefined();
+    expect(insertCall[1][0]).toBe(expectedStored);
+
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      "market.created",
+      expect.objectContaining({ question: expectedStored })
+    );
+  });
+});

--- a/backend/src/tests/markets-xss.test.js
+++ b/backend/src/tests/markets-xss.test.js
@@ -82,6 +82,7 @@ describe("POST /api/markets — question XSS sanitization", () => {
         endDate,
         outcomes: ["Yes", "No"],
         walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        categoryId: 1,
       });
 
     expect(res.status).toBe(201);
@@ -93,6 +94,7 @@ describe("POST /api/markets — question XSS sanitization", () => {
     );
     expect(insertCall).toBeDefined();
     expect(insertCall[1][0]).toBe(expectedStored);
+    expect(insertCall[1][4]).toBe(1);
 
     expect(eventBus.emit).toHaveBeenCalledWith(
       "market.created",

--- a/frontend/src/components/__tests__/TradeDrawer.test.tsx
+++ b/frontend/src/components/__tests__/TradeDrawer.test.tsx
@@ -65,6 +65,25 @@ describe("TradeDrawer", () => {
     );
     expect(screen.getByText("Will Bitcoin reach $100k?")).toBeInTheDocument();
   });
+
+  it("renders market question as text nodes only (no HTML injection from question string)", () => {
+    const payload =
+      "<script>document.body.setAttribute('data-xss','1')</script>Will Bitcoin reach $100k?";
+    render(
+      <TradeDrawer
+        market={{ ...SAMPLE_MARKET, question: payload }}
+        open={true}
+        onClose={() => {}}
+        walletAddress={null}
+      />
+    );
+    const drawer = screen.getByTestId("trade-drawer");
+    const heading = drawer.querySelector("h3");
+    expect(heading).toBeTruthy();
+    expect(heading?.textContent).toBe(payload);
+    expect(heading?.innerHTML).not.toMatch(/<script/i);
+    expect(drawer.querySelectorAll("script")).toHaveLength(0);
+  });
 });
 
 // --- Swipe gesture helpers ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "prom-client": "^15.1.3",
+        "sanitize-html": "^2.17.0",
         "ws": "^8.20.0"
       },
       "devDependencies": {
@@ -10852,6 +10853,73 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -11288,7 +11356,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -13523,6 +13590,37 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -14223,7 +14321,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18725,6 +18822,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -20453,6 +20556,20 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.2.tgz",
+      "integrity": "sha512-EnffJUl46VE9uvZ0XeWzObHLurClLlT12gsOk1cHyP2Ol1P0BnBnsXmShlBmWVJM+dKieQI68R0tsPY5m/B+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "prom-client": "^15.1.3",
-        "sanitize-html": "^2.17.0",
+        "sanitize-html": "^2.17.2",
         "ws": "^8.20.0"
       },
       "devDependencies": {


### PR DESCRIPTION
Closes #590

## Summary
Addresses stored XSS risk for market `question` by stripping all HTML before persistence, sending a baseline `Content-Security-Policy` on API responses, and locking in safe rendering/tests on the frontend.

## Changes
- **Backend:** Add `sanitize-html` and sanitize `question` with `{ allowedTags: [], allowedAttributes: {} }` before `INSERT` / logging / `market.created` event payload (`backend/src/routes/markets.js`).
- **Backend:** Set `Content-Security-Policy: default-src 'self'` for all HTTP responses (`backend/src/index.js`).
- **Tests:** `backend/src/tests/markets-xss.test.js` — POST with `<script>` / `<img onerror>` + long plain text; asserts DB bind param and JSON body contain stripped text and CSP header is present.
- **Frontend:** `TradeDrawer` test — market question with a script-like prefix is rendered as text only (`frontend/src/components/__tests__/TradeDrawer.test.tsx`).
- **Deps:** `sanitize-html` in `backend/package.json` + root `package-lock.json` (npm workspace).

## Definition of done (#590)
- [x] Script/HTML stripped before DB storage  
- [x] `Content-Security-Policy` on API responses  
- [x] Questions rendered as text (React children); regression test added  
- [x] Unit test for XSS payload stripping before storage  
- [ ] Repo-wide coverage &gt; 95% — run `npm test -- --coverage` in `backend` / `frontend` as needed; not claimed globally in this PR.

## How to test
cd backend && npm test -- src/tests/markets-xss.test.js
cd frontend && npm test -- TradeDrawer.test.tsx
